### PR TITLE
adding travis CI, sauce labs and basic unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js: node
+script:
+- npm run lint
+- polymer test --skip-plugin local
+addons:
+  jwt:
+    secure: ZobijriMmUSYBCr2kU0ImEY4TK8OJA/AiUlvrjjQhv1ViC7HvlSsk7lgPh9XBMLK/4WYHMDqAMJ80L6cFarKmhhecuttEdOyf5xLmeM8btyC58z6iE1e9+4Cr6MQr5OKmf4E8X72h5P/f8e0exWur0uPC78yJBq8hytT3WWU31WnD1M59rxaqB0Et/pbfFE/1u15ABkCYhb7ZdmcDXuVLACai6n3bpUJ2GaWzPtKtDCOllxUkrSYBIqMBBkcrmMOhGmvzB/vbV7LkoIErRFgPW8quO6UgsjGlxRgRfXTO3U7Nw+BJdFhm3kmK3TIxtl5zxhqTuVE0wDK4ndXIkB5zuZkmHmCGYt9R4pDr/fxdXjyckY/okjiCBlOokIF+qZalBJVKDlbuFDrY3skrgV3+ucyEbCOcbDRetAZ0IAII9+WQs57E/6781q1Txw8kNAtPXkICtKY2WzXjrA3FHQEMEO+v506+MiWwuU+nj4sq+UVUr1XjdBYkx0xVrblPO9JOCG3dcEhLGoLOr8zHrxwpMhc8UVwmCNFKtFZ/kvPAb0XpplGpRN0YXLO8+rg+Q/pqn9GZqtA6NCqnz3M0Bpc1bEAVHozk8OcBW3Hohen/mnLTAPCa4PMxqUM2DSvMda0UkLnfevdOa8X5HyV/bugAx8QzHx32jF9HpiHnLnd0Sw=
+env:
+  global:
+    SAUCE_USERNAME: Desire2Learn

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "scripts": {
     "postinstall": "polymer install --variants",
-    "test": "npm run test:lint:js && npm run test:lint:wc",
-    "test:lint:js": "eslint *.html demo/*.html",
-    "test:lint:wc": "polymer lint -i *.html"
+    "test": "npm run lint && polymer test --skip-plugin sauce",
+    "lint": "npm run lint:js && npm run lint:wc",
+    "lint:js": "eslint *.html demo/*.html test/*.html",
+    "lint:wc": "polymer lint -i *.html"
   },
   "homepage": "https://github.com/Brightspace/d2l-tile",
   "repository": {

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "brightspace/wct-config"
+}

--- a/test/d2l-image-tile.html
+++ b/test/d2l-image-tile.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-image-tile tests</title>
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../web-component-tester/browser.js"></script>
+		<link rel="import" href="../d2l-image-tile.html">
+	</head>
+	<body>
+		<test-fixture id="basic">
+			<template>
+				<d2l-image-tile></d2l-image-tile>
+			</template>
+		</test-fixture>
+		<script>
+			describe('d2l-image-tile', function() {
+				var elem;
+				describe('basic', function() {
+					it('should instantiate the element', function() {
+						elem = fixture('basic');
+						expect(elem.is).to.equal('d2l-image-tile');
+					});
+				});
+			});
+		</script>
+	</body>
+</html>

--- a/test/d2l-tile.html
+++ b/test/d2l-tile.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-tile tests</title>
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../web-component-tester/browser.js"></script>
+		<link rel="import" href="../d2l-tile.html">
+	</head>
+	<body>
+		<test-fixture id="basic">
+			<template>
+				<d2l-tile></d2l-tile>
+			</template>
+		</test-fixture>
+		<script>
+			describe('d2l-tile', function() {
+				var elem;
+				describe('basic', function() {
+					it('should instantiate the element', function() {
+						elem = fixture('basic');
+						expect(elem.is).to.equal('d2l-tile');
+					});
+				});
+			});
+		</script>
+	</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../web-component-tester/browser.js"></script>
+	</head>
+	<body>
+		<script>
+			WCT.loadSuites([
+				'd2l-tile.html?wc-shadydom=true&wc-ce=true',
+				'd2l-tile.html?dom=shadow',
+				'd2l-image-tile.html?wc-shadydom=true&wc-ce=true',
+				'd2l-image-tile.html?dom=shadow'
+			]);
+		</script>
+	</body>
+</html>

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,0 +1,46 @@
+{
+	"plugins": {
+		"local": {
+			"browsers": ["chrome"]
+		},
+		"sauce": {
+			"browsers": [
+				{
+					"browserName": "chrome",
+					"platform": "OS X 10.12",
+					"version": ""
+				},
+				{
+					"browserName": "chrome",
+					"platform": "Windows 10",
+					"version": ""
+				},
+				{
+					"browserName": "firefox",
+					"platform": "OS X 10.12",
+					"version": ""
+				},
+				{
+					"browserName": "firefox",
+					"platform": "Windows 10",
+					"version": ""
+				},
+				{
+					"browserName": "safari",
+					"platform": "OS X 10.12",
+					"version": ""
+				},
+				{
+					"browserName": "microsoftedge",
+					"platform": "Windows 10",
+					"version": ""
+				},
+				{
+					"browserName": "internet explorer",
+					"platform": "Windows 10",
+					"version": "11"
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
@jstefaniuk-d2l FYI

This adds Travis CI support and super basic unit tests that'll run in all our supported browsers via SauceLabs. We can add more targeted tests later.