### PR TITLE
More dropdown options for img-tile, more doesn't show if nothing in slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Alternatively, by specifying the `custom-image-format` attribute you can provide
 
 #### "More" menu
 
-To display a `...` "more" menu, set the `show-menu` attribute and provide content inside the `d2l-image-tile-menu` slot.
+To display a `...` "more" dropdown, provide content inside the `d2l-image-tile-dropdown` slot.
 
 **Note:** always provide an accessible label for the menu using the `dropdown-aria-label` attribute.
 
@@ -70,11 +70,13 @@ To display a `...` "more" menu, set the `show-menu` attribute and provide conten
 <link rel="import" href="bower_components/d2l-menu/d2l-menu.html">
 <link rel="import" href="bower_components/d2l-menu/d2l-menu-item.html">
 <d2l-image-tile show-menu dropdown-aria-label="Tile Options">
-	<d2l-menu slot="d2l-image-tile-menu">
-		<d2l-menu-item text="Menu item one"></d2l-menu-item>
-		<d2l-menu-item text="Menu item two"></d2l-menu-item>
-		<d2l-menu-item text="Menu item three"></d2l-menu-item>
-	</d2l-menu>
+	<d2l-dropdown-menu slot="d2l-image-tile-dropdown">
+		<d2l-menu>
+			<d2l-menu-item text="Menu item one"></d2l-menu-item>
+			<d2l-menu-item text="Menu item two"></d2l-menu-item>
+			<d2l-menu-item text="Menu item three"></d2l-menu-item>
+		</d2l-menu>
+	</d2l-dropdown-menu>
 </d2l-image-tile>
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To display a `...` "more" dropdown, provide content inside the `d2l-image-tile-d
 ```html
 <link rel="import" href="bower_components/d2l-menu/d2l-menu.html">
 <link rel="import" href="bower_components/d2l-menu/d2l-menu-item.html">
-<d2l-image-tile show-menu dropdown-aria-label="Tile Options">
+<d2l-image-tile dropdown-aria-label="Tile Options">
 	<d2l-dropdown-menu slot="d2l-image-tile-dropdown">
 		<d2l-menu>
 			<d2l-menu-item text="Menu item one"></d2l-menu-item>

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -214,22 +214,20 @@
 			Polymer.RenderStatus.afterNextRender(this, function() {
 				this.addEventListener('focus', this._onFocus.bind(this), true);
 				this.addEventListener('blur', this._onBlur.bind(this), true);
+				var slot = this.shadowRoot.querySelector('#dropdown-slot');
 				this.showMenu = this._isDropdownSlotFilled();
-				slot.addEventListener('slotchange', function(e) {
+				slot.addEventListener('slotchange', function() {
 					this.showMenu = this._isDropdownSlotFilled();
 				});
 			}.bind(this));
 		},
 		_isDropdownSlotFilled: function() {
-			var slot = this.shadowRoot.querySelector('slot#dropdown-slot');
+			var slot = this.shadowRoot.querySelector('#dropdown-slot');
 			if (!slot) {
 				return false;
 			}
 			var slotElements = slot.assignedNodes();
-			if (slotElements === undefined || slotElements.length === 0) {
-				return false;
-			}
-			return true;
+			return slotElements && slotElements.length > 0;
 		},
 		_onDropdownClick: function(e) {
 			e.stopPropagation();

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -12,10 +12,6 @@
 <dom-module id="d2l-image-tile">
 	<template strip-whitespace>
 		<style>
-			:host([show-menu]) {
-				overflow: visible;
-			}
-
 			:host([loading]) {
 				cursor: default;
 			}
@@ -28,7 +24,6 @@
 				cursor: pointer;
 				display: block;
 				font: inherit;
-				overflow: hidden;
 				position: relative;
 				text-align: center;
 				width: 350px;
@@ -142,13 +137,14 @@
 			</template>
 		</div>
 		<d2l-dropdown on-tap="_onDropdownClick">
-			<template is="dom-if" if="[[_shouldShowMenu(showMenu, loading)]]">
-				<d2l-dropdown-more id="dropdown-more" label="[[dropdownAriaLabel]]">
-					<slot name="d2l-image-tile-dropdown"
-						id="dropdown-slot"
-						on-slot-changed="_handleSlotChange"></slot>
-				</d2l-dropdown-more>
-			</template>
+			<d2l-dropdown-more
+				id="dropdown-more"
+				label="[[dropdownAriaLabel]]"
+				hidden$="[[!_shouldShowMenu(_showMenu, loading)]]">
+				<slot name="d2l-image-tile-dropdown"
+					id="dropdown-slot"
+					on-slot-changed="_handleSlotChange"></slot>
+			</d2l-dropdown-more>
 		</d2l-dropdown>
 		<div class="d2l-image-tile-content-container">
 			<slot></slot>
@@ -172,16 +168,15 @@
 			 * When true, shows a '...' "more" menu that opens a dropdown menu
 			 * comprised of the contents of the `d2l-image-tile-menu` slot.
 			 */
-			showMenu: {
+			_showMenu: {
 				type: Boolean,
-				value: false,
-				reflectToAttribute: true
+				value: false
 			},
 			/**
 			 * When true, shows the contents of the `d2l-image-tile-image` slot
 			 * rather than using the imageUrl.
 			 */
-			customImageFormat: Boolean,
+			 customImageFormat: Boolean,
 			/**
 			 * A space-separated string listing the hover effect to be applied
 			 * to the tile.
@@ -220,10 +215,10 @@
 			}.bind(this));
 		},
 		_handleSlotChanged: function() {
-			this.showMenu = this._isDropdownSlotFilled();
+			this._showMenu = this._isDropdownSlotFilled();
 		},
 		_isDropdownSlotFilled: function() {
-			var slot = this.$.dropdownSlot;
+			var slot = this.$['dropdown-slot'];
 			if (!slot) {
 				return false;
 			}

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -12,6 +12,10 @@
 <dom-module id="d2l-image-tile">
 	<template strip-whitespace>
 		<style>
+			[hidden] {
+				display: none;
+			}
+
 			:host([loading]) {
 				cursor: default;
 			}

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -176,7 +176,7 @@
 			 * When true, shows the contents of the `d2l-image-tile-image` slot
 			 * rather than using the imageUrl.
 			 */
-			 customImageFormat: Boolean,
+			customImageFormat: Boolean,
 			/**
 			 * A space-separated string listing the hover effect to be applied
 			 * to the tile.

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -1,7 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-icons/tier1-icons.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown.html">
-<link rel="import" href="../d2l-dropdown/d2l-dropdown-menu.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-more.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
 <link rel="import" href="./d2l-tile-behavior.html">
@@ -145,9 +144,7 @@
 		<d2l-dropdown on-tap="_onDropdownClick">
 			<template is="dom-if" if="[[_shouldShowMenu(showMenu, loading)]]">
 				<d2l-dropdown-more id="dropdown-more" label="[[dropdownAriaLabel]]">
-					<d2l-dropdown-menu id="overflow-dropdown">
-						<slot name="d2l-image-tile-menu"></slot>
-					</d2l-dropdown-menu>
+					<slot name="d2l-image-tile-dropdown" id='dropdown-slot'></slot>
 				</d2l-dropdown-more>
 			</template>
 		</d2l-dropdown>
@@ -217,7 +214,22 @@
 			Polymer.RenderStatus.afterNextRender(this, function() {
 				this.addEventListener('focus', this._onFocus.bind(this), true);
 				this.addEventListener('blur', this._onBlur.bind(this), true);
+				this.showMenu = this._isDropdownSlotFilled();
+				slot.addEventListener('slotchange', function(e) {
+					this.showMenu = this._isDropdownSlotFilled();
+				});
 			}.bind(this));
+		},
+		_isDropdownSlotFilled: function() {
+			var slot = this.shadowRoot.querySelector('slot#dropdown-slot');
+			if (!slot) {
+				return false;
+			}
+			var slotElements = slot.assignedNodes();
+			if (slotElements === undefined || slotElements.length === 0) {
+				return false;
+			}
+			return true;
 		},
 		_onDropdownClick: function(e) {
 			e.stopPropagation();

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -144,7 +144,9 @@
 		<d2l-dropdown on-tap="_onDropdownClick">
 			<template is="dom-if" if="[[_shouldShowMenu(showMenu, loading)]]">
 				<d2l-dropdown-more id="dropdown-more" label="[[dropdownAriaLabel]]">
-					<slot name="d2l-image-tile-dropdown" id='dropdown-slot'></slot>
+					<slot name="d2l-image-tile-dropdown"
+						id="dropdown-slot"
+						on-slot-changed="_handleSlotChange"></slot>
 				</d2l-dropdown-more>
 			</template>
 		</d2l-dropdown>
@@ -214,15 +216,14 @@
 			Polymer.RenderStatus.afterNextRender(this, function() {
 				this.addEventListener('focus', this._onFocus.bind(this), true);
 				this.addEventListener('blur', this._onBlur.bind(this), true);
-				var slot = this.shadowRoot.querySelector('#dropdown-slot');
-				this.showMenu = this._isDropdownSlotFilled();
-				slot.addEventListener('slotchange', function() {
-					this.showMenu = this._isDropdownSlotFilled();
-				});
+				this._handleSlotChanged();
 			}.bind(this));
 		},
+		_handleSlotChanged: function() {
+			this.showMenu = this._isDropdownSlotFilled();
+		},
 		_isDropdownSlotFilled: function() {
-			var slot = this.shadowRoot.querySelector('#dropdown-slot');
+			var slot = this.$.dropdownSlot;
 			if (!slot) {
 				return false;
 			}

--- a/demo/d2l-image-tile.html
+++ b/demo/d2l-image-tile.html
@@ -10,6 +10,7 @@
 		<link rel="import" href="../../d2l-typography/d2l-typography.html">
 		<link rel="import" href="../../d2l-menu/d2l-menu.html">
 		<link rel="import" href="../../d2l-menu/d2l-menu-item.html">
+		<link rel="import" href="../../d2l-dropdown/d2l-dropdown-menu.html">
 		<link rel="import" href="../d2l-image-tile.html">
 		<custom-style>
 			<style is="custom-style" include="demo-pages-shared-styles"></style>
@@ -30,11 +31,13 @@
 				<template>
 					<d2l-image-tile img-url="https://s.brightspace.com/course-images/images/51fbf3cc-2149-4d88-890c-46efaca3ef8c/tile-high-density-mid-size.jpg" show-menu dropdown-aria-label="This is my menu">
 						<p>Tile content</p>
-						<d2l-menu slot="d2l-image-tile-menu">
-							<d2l-menu-item text="Menu item one"></d2l-menu-item>
-							<d2l-menu-item text="Menu item two"></d2l-menu-item>
-							<d2l-menu-item text="Menu item three"></d2l-menu-item>
-						</d2l-menu>
+						<d2l-dropdown-menu slot="d2l-image-tile-dropdown">
+							<d2l-menu>
+								<d2l-menu-item text="Menu item one"></d2l-menu-item>
+								<d2l-menu-item text="Menu item two"></d2l-menu-item>
+								<d2l-menu-item text="Menu item three"></d2l-menu-item>
+							</d2l-menu>
+						</d2l-dropdown-menu>
 					</d2l-image-tile>
 				</template>
 			</demo-snippet>

--- a/demo/d2l-image-tile.html
+++ b/demo/d2l-image-tile.html
@@ -29,7 +29,7 @@
 			<h3>Image tile with URL image and menu</h3>
 			<demo-snippet>
 				<template>
-					<d2l-image-tile img-url="https://s.brightspace.com/course-images/images/51fbf3cc-2149-4d88-890c-46efaca3ef8c/tile-high-density-mid-size.jpg" show-menu dropdown-aria-label="This is my menu">
+					<d2l-image-tile img-url="https://s.brightspace.com/course-images/images/51fbf3cc-2149-4d88-890c-46efaca3ef8c/tile-high-density-mid-size.jpg" dropdown-aria-label="This is my menu">
 						<p>Tile content</p>
 						<d2l-dropdown-menu slot="d2l-image-tile-dropdown">
 							<d2l-menu>


### PR DESCRIPTION
For issue #20 

Also this takes care of the "more" menu part of issue #23 by having no menu show up if there's nothing in the slot.

Demo has been updated to match