### PR TITLE
Replaced uses of slots API with old Polymer.dom

### DIFF
--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -210,7 +210,9 @@
 			}.bind(this));
 		},
 		detached: function() {
-			Polymer.dom(this.$['dropdown-slot']).unobserveNodes(this._slotObserver);
+			if (this._slotObserver) {
+				Polymer.dom(this.$['dropdown-slot']).unobserveNodes(this._slotObserver);
+			}
 		},
 		_handleSlotChanged: function() {
 			this._showMenu = this._isDropdownSlotFilled();

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -193,7 +193,8 @@
 				type: Boolean,
 				value: false,
 				reflectToAttribute: true
-			}
+			},
+			_slotObserver: Object
 		},
 		hostAttributes: {
 			tabindex: 0
@@ -205,7 +206,11 @@
 		attached: function() {
 			Polymer.RenderStatus.afterNextRender(this, function() {
 				this._handleSlotChanged();
+				this._slotObserver = Polymer.dom(this.$['dropdown-slot']).observeNodes(this._handleSlotChanged.bind(this));
 			}.bind(this));
+		},
+		detached: function() {
+			Polymer.dom(this.$['dropdown-slot']).unobserveNodes(this._slotObserver);
 		},
 		_handleSlotChanged: function() {
 			this._showMenu = this._isDropdownSlotFilled();
@@ -215,7 +220,7 @@
 			if (!slot) {
 				return false;
 			}
-			var slotElements = slot.assignedNodes();
+			var slotElements = Polymer.dom(slot).getDistributedNodes();
 			return slotElements && slotElements.length > 0;
 		},
 		_onDropdownClick: function(e) {


### PR DESCRIPTION
The polymer 1 demo was broken because of using the slots API (`slot`s are also replaced with `content`s in polymer 1)

Thanks to @jstefaniuk-d2l for finding that it was broken (I was only checking the hybrid demos, oops)