### PR TITLE
Allow disable show if mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ To display a `...` "more" dropdown, provide content inside the `d2l-image-tile-d
 </d2l-image-tile>
 ```
 
+#### Menu-adjacent content
+
+If you need to add an element to the right of the "more" menu, you can use the `d2l-image-tile-menu-adjacent` slot.
+
 #### Loading State
 
 The image tile can be placed in an initial "loading" state:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To display a `...` "more" dropdown, provide content inside the `d2l-image-tile-d
 </d2l-image-tile>
 ```
 
-The `...` mwny will always show on mobile, unless you set the `no-mobile-more-button` attribute to true.
+The `...` menu will always show on mobile, unless you set the `no-mobile-more-button` attribute to true.
 
 #### Menu-adjacent content
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ To display a `...` "more" dropdown, provide content inside the `d2l-image-tile-d
 </d2l-image-tile>
 ```
 
+The `...` mwny will always show on mobile, unless you set the `no-mobile-more-button` attribute to true.
+
 #### Menu-adjacent content
 
 If you need to add an element to the right of the "more" menu, you can use the `d2l-image-tile-menu-adjacent` slot.

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -187,12 +187,32 @@
 				margin-right: 15px;
 			}
 
+			:host-context([dir="rtl"]) .d2l-image-tile-menu-adjacent-container ::slotted(*) {
+				margin-right: 0;
+				margin-left: 15px;
+			}
+
+			:host(:dir(rtl)) .d2l-image-tile-menu-adjacent-container ::slotted(*) {
+				margin-right: 0;
+				margin-left: 15px;
+			}
+
 			.d2l-image-tile-menu-area {
 				position: absolute;
 				right: 0;
 				top: 0;
 				margin-top: 15px;
 				display: flex;
+			}
+
+			:host-context([dir="rtl"]) .d2l-image-tile-menu-area {
+				left: 0;
+				right: auto;
+			}
+
+			:host(:dir(rtl)) .d2l-image-tile-menu-area {
+				left: 0;
+				right: auto;
 			}
 		</style>
 		<div class="d2l-image-tile-image-container">

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -35,6 +35,7 @@
 
 			:host([no-mobile-more-button]) d2l-dropdown-more {
 				opacity: 0;
+				display: none;
 				pointer-events: none;
 			}
 
@@ -117,12 +118,20 @@
 					pointer-events: all;
 				}
 
+				:host([no-mobile-more-button]) d2l-dropdown-more {
+					display: inline-block;
+				}
+
 				d2l-dropdown-more {
 					opacity: 0;
 				}
 			}
 
 			@media only screen and (-moz-touch-enabled: 1) {
+				:host([no-mobile-more-button]) d2l-dropdown-more {
+					display: inline-block;
+				}
+
 				:host([no-mobile-more-button]:hover) d2l-dropdown-more,
 				:host([no-mobile-more-button][focused]) d2l-dropdown-more,
 				:host([no-mobile-more-button][menu-opened]) d2l-dropdown-more {

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -73,10 +73,6 @@
 				transition: margin-top .25s;
 			}
 
-			:host([hover-effect~="lower-menu"]:not(:hover):not([focused]):not([menu-opened])) d2l-dropdown {
-				margin-top: -15px;
-			}
-
 			:host-context([dir="rtl"]) d2l-dropdown {
 				left: 0;
 				right: auto;
@@ -92,14 +88,12 @@
 			}
 
 			@media only screen and (hover: hover), only screen and (-moz-touch-enabled: 0) {
+				:host([hover-effect~="lower-menu"]:not(:hover):not([focused]):not([menu-opened])) d2l-dropdown {
+					margin-top: -15px;
+				}
+
 				d2l-dropdown-more {
 					opacity: 0;
-				}
-			}
-
-			@media only screen and (-moz-touch-enabled: 1) {
-				:host([hover-effect~="lower-menu"]:not(:hover):not([focused]):not([menu-opened])) d2l-dropdown {
-					margin-top: 0;
 				}
 			}
 

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -33,10 +33,20 @@
 				width: 350px;
 			}
 
-			:host(:hover) d2l-dropdown-more,
-			:host([focused]) d2l-dropdown-more,
-			:host([menu-opened]) d2l-dropdown-more {
+			:host([no-mobile-more-button]) d2l-dropdown-more {
+				opacity: 0;
+				pointer-events: none;
+			}
+
+			:host([no-mobile-more-button][hover-effect~="lower-menu"]:not(:hover):not([focused]):not([menu-opened])) d2l-dropdown {
+				margin-top: -15px;
+			}
+
+			:host(:not([no-mobile-more-button]):hover) d2l-dropdown-more,
+			:host(:not([no-mobile-more-button])[focused]) d2l-dropdown-more,
+			:host(:not([no-mobile-more-button])[menu-opened]) d2l-dropdown-more {
 				opacity: 1;
+				pointer-events: all;
 			}
 
 			.d2l-image-tile-image-container {
@@ -92,8 +102,28 @@
 					margin-top: -15px;
 				}
 
+				:host([focused]) d2l-dropdown-more {
+					opacity: 1;
+				}
+
+				:host(:hover) d2l-dropdown-more,
+				:host([focused]) d2l-dropdown-more,
+				:host([menu-opened]) d2l-dropdown-more {
+					opacity: 1;
+					pointer-events: all;
+				}
+
 				d2l-dropdown-more {
 					opacity: 0;
+				}
+			}
+
+			@media only screen and (-moz-touch-enabled: 1) {
+				:host([no-mobile-more-button]:hover) d2l-dropdown-more,
+				:host([no-mobile-more-button][focused]) d2l-dropdown-more,
+				:host([no-mobile-more-button][menu-opened]) d2l-dropdown-more {
+					opacity: 1;
+					pointer-events: all;
 				}
 			}
 
@@ -291,6 +321,10 @@
 			focused: {
 				type: Boolean,
 				value: false,
+				reflectToAttribute: true
+			},
+			noMobileMoreButton: {
+				type: Boolean,
 				reflectToAttribute: true
 			},
 			_slotObserver: Object

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -67,15 +67,14 @@
 			}
 
 			d2l-dropdown {
-				margin: 15px;
-				position: absolute;
+				margin: 0 15px 15px 15px;
 				right: 0;
 				top: 0;
 				transition: margin-top .25s;
 			}
 
 			:host([hover-effect~="lower-menu"]:not(:hover):not([focused]):not([menu-opened])) d2l-dropdown {
-				margin-top: 0px;
+				margin-top: -15px;
 			}
 
 			:host-context([dir="rtl"]) d2l-dropdown {
@@ -100,7 +99,7 @@
 
 			@media only screen and (-moz-touch-enabled: 1) {
 				:host([hover-effect~="lower-menu"]:not(:hover):not([focused]):not([menu-opened])) d2l-dropdown {
-					margin-top: 15px;
+					margin-top: 0;
 				}
 			}
 
@@ -183,6 +182,18 @@
 			:host([hover-effect~="low-lift"]:not([loading])[focused])::after {
 				opacity: 1;
 			}
+
+			.d2l-image-tile-menu-adjacent-container ::slotted(*)  {
+				margin-right: 15px;
+			}
+
+			.d2l-image-tile-menu-area {
+				position: absolute;
+				right: 0;
+				top: 0;
+				margin-top: 15px;
+				display: flex;
+			}
 		</style>
 		<div class="d2l-image-tile-image-container">
 			<div class="d2l-image-tile-image-area">
@@ -199,17 +210,23 @@
 				</template>
 			</div>
 		</div>
-		<d2l-dropdown on-tap="_onDropdownClick">
-			<d2l-dropdown-more
-				id="dropdown-more"
-				label="[[dropdownLabel]]"
-				hidden$="[[!_shouldShowMenu(_showMenu, loading)]]">
-				<slot name="d2l-image-tile-dropdown"
-					id="dropdown-slot"
-					on-slot-changed="_handleSlotChange">
+		<div class="d2l-image-tile-menu-area">
+			<d2l-dropdown on-tap="_onDropdownClick">
+				<d2l-dropdown-more
+					id="dropdown-more"
+					label="[[dropdownLabel]]"
+					hidden$="[[!_shouldShowMenu(_showMenu, loading)]]">
+					<slot name="d2l-image-tile-dropdown"
+						id="dropdown-slot"
+						on-slot-changed="_handleSlotChange">
+					</slot>
+				</d2l-dropdown-more>
+			</d2l-dropdown>
+			<div class="d2l-image-tile-menu-adjacent-container">
+				<slot name="d2l-image-tile-menu-adjacent">
 				</slot>
-			</d2l-dropdown-more>
-		</d2l-dropdown>
+			</div>
+		</div>
 		<div class="d2l-image-tile-content-container">
 			<slot></slot>
 		</div>

--- a/demo/d2l-image-tile.html
+++ b/demo/d2l-image-tile.html
@@ -97,6 +97,7 @@
 						hover-effect="emphasize-image lower-menu"
 						onclick="clicky()"
 						class="course-tile"
+						no-mobile-more-button
 					>
 						<p class="hover-underline">Click to toggle menu-adjacent content</p>
 						<d2l-dropdown-menu slot="d2l-image-tile-dropdown">

--- a/demo/d2l-image-tile.html
+++ b/demo/d2l-image-tile.html
@@ -42,11 +42,41 @@
 				</template>
 			</demo-snippet>
 
-			<h3>Image tile with the emphasize-image and lower-menu hover effect</h3>
+			<h3>Image tile with the emphasize-image, lower-menu hover effect, and menu-adjacent content</h3>
 			<demo-snippet>
 				<template>
-					<d2l-image-tile img-url="https://s.brightspace.com/course-images/images/51fbf3cc-2149-4d88-890c-46efaca3ef8c/tile-high-density-mid-size.jpg" dropdown-label="This is my menu" hover-effect="emphasize-image lower-menu">
-						<p>Tile content</p>
+					<custom-style>
+						<style is="custom-style">
+							.menu-adjacent {
+								height: 35px;
+								width: 35px;
+								border-radius: 7px;
+								background: lightcyan;
+								opacity: 0.7;
+							}
+
+							.menu-adjacent:hover {
+								background: white;
+							}
+
+							[hidden] {
+								display: none;
+							}
+						</style>
+					</custom-style>
+					<script>
+						function clicky() { // eslint-disable-line no-unused-vars
+							var item = document.querySelector('.menu-adjacent');
+							item.hidden = !item.hidden;
+						}
+					</script>
+					<d2l-image-tile
+						img-url="https://s.brightspace.com/course-images/images/51fbf3cc-2149-4d88-890c-46efaca3ef8c/tile-high-density-mid-size.jpg"
+						dropdown-label="This is my menu"
+						hover-effect="emphasize-image lower-menu"
+						onclick="clicky()"
+					>
+						<p>Click to toggle menu-adjacent content</p>
 						<d2l-dropdown-menu slot="d2l-image-tile-dropdown">
 							<d2l-menu>
 								<d2l-menu-item text="Menu item one"></d2l-menu-item>
@@ -54,6 +84,7 @@
 								<d2l-menu-item text="Menu item three"></d2l-menu-item>
 							</d2l-menu>
 						</d2l-dropdown-menu>
+						<div class="menu-adjacent" slot="d2l-image-tile-menu-adjacent"></div>
 					</d2l-image-tile>
 				</template>
 			</demo-snippet>

--- a/demo/d2l-image-tile.html
+++ b/demo/d2l-image-tile.html
@@ -42,7 +42,7 @@
 				</template>
 			</demo-snippet>
 
-			<h3>Image tile making up a course tile</h3>
+			<h3>Image tile made up to look like a course tile</h3>
 			<demo-snippet>
 				<template>
 					<custom-style>

--- a/demo/d2l-image-tile.html
+++ b/demo/d2l-image-tile.html
@@ -42,7 +42,7 @@
 				</template>
 			</demo-snippet>
 
-			<h3>Image tile with the emphasize-image, lower-menu hover effect, and menu-adjacent content</h3>
+			<h3>Image tile making up a course tile</h3>
 			<demo-snippet>
 				<template>
 					<custom-style>
@@ -79,6 +79,10 @@
 							.course-tile {
 								border-color: transparent;
 							}
+
+							d2l-image-tile:hover .hover-underline {
+								text-decoration: underline;
+							}
 						</style>
 					</custom-style>
 					<script>
@@ -94,7 +98,7 @@
 						onclick="clicky()"
 						class="course-tile"
 					>
-						<p>Click to toggle menu-adjacent content</p>
+						<p class="hover-underline">Click to toggle menu-adjacent content</p>
 						<d2l-dropdown-menu slot="d2l-image-tile-dropdown">
 							<d2l-menu>
 								<d2l-menu-item text="Menu item one"></d2l-menu-item>

--- a/demo/d2l-image-tile.html
+++ b/demo/d2l-image-tile.html
@@ -75,6 +75,10 @@
  								margin-right: 0;
 								margin-left: 10px;
 							}
+
+							.course-tile {
+								border-color: transparent;
+							}
 						</style>
 					</custom-style>
 					<script>
@@ -88,6 +92,7 @@
 						dropdown-label="This is my menu"
 						hover-effect="emphasize-image lower-menu"
 						onclick="clicky()"
+						class="course-tile"
 					>
 						<p>Click to toggle menu-adjacent content</p>
 						<d2l-dropdown-menu slot="d2l-image-tile-dropdown">

--- a/demo/d2l-image-tile.html
+++ b/demo/d2l-image-tile.html
@@ -53,21 +53,34 @@
 								border-radius: 7px;
 								background: lightcyan;
 								opacity: 0.7;
+								margin-right: 10px;
+								transition: opacity 0.25s, width 0.15s, margin-right 0.25s, padding-left 0.25s, padding-right 0.25s
 							}
 
 							.menu-adjacent:hover {
 								background: white;
 							}
 
-							[hidden] {
-								display: none;
+							.hidden {
+								visibility: hidden;
+								width: 0.1px; /* needed so d2l-icon doesnt overflow on safari */
+								margin-right: 0;
+								margin-left: 0;
+								padding-left: 0;
+								padding-right: 0;
+								opacity: 0;
+							}
+
+							[dir="rtl"] .menu-adjacent {
+ 								margin-right: 0;
+								margin-left: 10px;
 							}
 						</style>
 					</custom-style>
 					<script>
 						function clicky() { // eslint-disable-line no-unused-vars
 							var item = document.querySelector('.menu-adjacent');
-							item.hidden = !item.hidden;
+							item.classList.toggle('hidden');
 						}
 					</script>
 					<d2l-image-tile


### PR DESCRIPTION
Right now the `...` menu shows by default when on a mobile device, this PR adds an attribute `no-mobile-more-button` to override that behavior (Example of a use case would be the my-courses course-tile)

Based off of: https://github.com/BrightspaceUI/tile/pull/43
  