### PR TITLE
Give menu contents a higher z-index

### DIFF
--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -240,6 +240,7 @@
 				top: 0;
 				margin-top: 15px;
 				display: flex;
+				z-index: 3;
 			}
 
 			:host-context([dir="rtl"]) .d2l-image-tile-menu-area {


### PR DESCRIPTION
Minor thing, but if you follow the approach of using a negative `top` value to overlay something on the image, it ends up being on top of the dropdown menu. To avoid this, we can move the menu to a z-index of 3 - there doesn't seem to be any case where we'd want something to cover up the menu anyway, so the approach seems sound.