### PR TITLE
Fix menu NVDA, add "href" property, fix 1.x focus effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Include the [webcomponents.js](http://webcomponents.org/polyfills/) "lite" polyf
 </d2l-tile>
 ```
 
+#### Making the tile into a link:
+You can make the tile into a link by passing in a `href` property
+
 ### d2l-image-tile
 
 An extension of `<d2l-tile>`, `<d2l-image-tile>` adds an image at the top, content at the bottom, and an optional `...` "more" menu which can launch a [d2l-dropdown-menu](https://github.com/BrightspaceUI/dropdown#menu-content).
@@ -135,6 +138,9 @@ Alternatively, you can provide custom image content in the `d2l-image-tile-image
 	</div>
 </d2l-image-tile>
 ```
+
+#### Making the image tile into a link:
+You can make the tile into a link by passing in a `href` property
 
 #### "More" menu
 

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "wct.conf.json"
   ],
   "dependencies": {
-    "d2l-colors": "^2.4.0 || ^3.1.0",
+    "d2l-colors": "^3.1.2",
     "d2l-dropdown": "^5.2.1 || ^6.0.0",
     "polymer": "1 - 2"
   },
@@ -27,10 +27,12 @@
     "web-component-tester": "^6.0.0",
     "d2l-menu": "^0.3.7 || ^1.0.3"
   },
+  "resolutions": {
+    "d2l-colors": "^3.1.2"
+  },
   "variants": {
     "1.x": {
       "dependencies": {
-        "d2l-colors": "^2.4.0",
         "d2l-dropdown": "^5.2.1",
         "polymer": "^1.11.0"
       },

--- a/d2l-image-tile-base.html
+++ b/d2l-image-tile-base.html
@@ -17,12 +17,12 @@
 				border-color: inherit;
 			}
 		</style>
-		<template is="dom-if" if="[[href]]">
-			<a class="d2l-image-tile-base-link" href=[[href]]>
+		<template is="dom-if" if="href=[[_hasHref(href)]]">
+			<a class="d2l-image-tile-base-link" href$=[[href]]>
 				<slot name="d2l-image-tile-base-content"></slot>
 			</a>
 		</template>
-		<template is="dom-if" if="[[!href]]">
+		<template is="dom-if" if="[[!_hasHref(href)]]">
 			<div class="d2l-image-tile-base-div" tabindex="0">
 				<slot name="d2l-image-tile-base-content"></slot>
 			</div>
@@ -37,6 +37,9 @@
 				type: String,
 				value: null
 			}
+		},
+		_hasHref: function(href) {
+			return href !== undefined && href !== null;
 		}
 	});
 	</script>

--- a/d2l-image-tile-base.html
+++ b/d2l-image-tile-base.html
@@ -1,0 +1,43 @@
+<link rel="import" href="../polymer/polymer.html">
+
+<dom-module id="d2l-image-tile-base">
+	<template strip-whitespace>
+		<style>
+			:host {
+				border-color: inherit;
+			}
+
+			.d2l-image-tile-base-link {
+				color: black;
+				text-decoration: none;
+				border-color: inherit;
+			}
+
+			.d2l-image-tile-base-div {
+				border-color: inherit;
+			}
+		</style>
+		<template is="dom-if" if="[[href]]">
+			<a class="d2l-image-tile-base-link" href=[[href]]>
+				<slot name="d2l-image-tile-base-content"></slot>
+			</a>
+		</template>
+		<template is="dom-if" if="[[!href]]">
+			<div class="d2l-image-tile-base-div" tabindex="0">
+				<slot name="d2l-image-tile-base-content"></slot>
+			</div>
+		</template>
+		<slot name="d2l-image-tile-base-menu-area"></slot>
+	</template>
+	<script>
+	Polymer({
+		is: 'd2l-image-tile-base',
+		properties: {
+			href: {
+				type: String,
+				value: null
+			}
+		}
+	});
+	</script>
+</dom-module>

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -4,6 +4,7 @@
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-more.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
 <link rel="import" href="./d2l-tile-behavior.html">
+<link rel="import" href="./d2l-image-tile-base.html">
 <!--
 `d2l-image-tile` is a Polymer-based web component for creating a tile with
 * an image at the top and an optional dropdown menu.
@@ -31,6 +32,8 @@
 				position: relative;
 				text-align: center;
 				width: 350px;
+				display: flex;
+				flex-direction: column-reverse;
 			}
 
 			:host([no-mobile-more-button]) d2l-dropdown-more {
@@ -258,43 +261,45 @@
 				right: auto;
 			}
 		</style>
-		<div class="d2l-image-tile-menu-area">
-			<d2l-dropdown on-tap="_onDropdownClick">
-				<d2l-dropdown-more
-					id="dropdown-more"
-					label="[[dropdownLabel]]"
-					hidden$="[[!_shouldShowMenu(_showMenu, loading)]]">
-					<slot name="d2l-image-tile-dropdown"
-						id="dropdown-slot"
-						on-slot-changed="_handleSlotChange">
-					</slot>
-				</d2l-dropdown-more>
-			</d2l-dropdown>
-			<div class="d2l-image-tile-menu-adjacent-container">
-				<slot name="d2l-image-tile-menu-adjacent">
-				</slot>
-			</div>
-		</div>
-		<div class="d2l-image-tile-container" tabindex="0">
-			<div class="d2l-image-tile-image-container">
-				<div class="d2l-image-tile-image-area">
-					<template is="dom-if" if="[[loading]]">
-						<div class="d2l-image-tile-loading-shimmer d2l-image-tile-image"></div>
-					</template>
-					<template is="dom-if" if="[[!loading]]">
-						<slot name="d2l-image-tile-image">
-							<div
-								class="d2l-image-tile-image"
-								style$="[[_getImageStyle(imgUrl)]]"
-							></div>
+		<d2l-image-tile-base href="[[href]]">
+			<div class="d2l-image-tile-menu-area" slot="d2l-image-tile-base-menu-area">
+				<d2l-dropdown on-tap="_onDropdownClick">
+					<d2l-dropdown-more
+						id="dropdown-more"
+						label="[[dropdownLabel]]"
+						hidden$="[[!_shouldShowMenu(_showMenu, loading)]]">
+						<slot name="d2l-image-tile-dropdown"
+							id="dropdown-slot"
+							on-slot-changed="_handleSlotChange">
 						</slot>
-					</template>
+					</d2l-dropdown-more>
+				</d2l-dropdown>
+				<div class="d2l-image-tile-menu-adjacent-container">
+					<slot name="d2l-image-tile-menu-adjacent">
+					</slot>
 				</div>
 			</div>
-			<div class="d2l-image-tile-content-container">
-				<slot></slot>
+			<div class="d2l-image-tile-container" slot="d2l-image-tile-base-content">
+				<div class="d2l-image-tile-image-container">
+					<div class="d2l-image-tile-image-area">
+						<template is="dom-if" if="[[loading]]">
+							<div class="d2l-image-tile-loading-shimmer d2l-image-tile-image"></div>
+						</template>
+						<template is="dom-if" if="[[!loading]]">
+							<slot name="d2l-image-tile-image">
+								<div
+									class="d2l-image-tile-image"
+									style$="[[_getImageStyle(imgUrl)]]"
+								></div>
+							</slot>
+						</template>
+					</div>
+				</div>
+				<div class="d2l-image-tile-content-container">
+					<slot></slot>
+				</div>
 			</div>
-		</div>
+		</d2l-image-tile-base>
 	</template>
 	<script>
 	Polymer({
@@ -344,23 +349,37 @@
 				value: false,
 				reflectToAttribute: true
 			},
+			/**
+			 * Overrides the default behavior of always showing the ... button on mobile
+			 */
 			noMobileMoreButton: {
 				type: Boolean,
 				reflectToAttribute: true
 			},
-			_slotObserver: Object
+			_slotObserver: Object,
+			/**
+			 * A location to go when you click on the tile
+			 */
+			href: {
+				type: String,
+				value: null
+			}
 		},
 		listeners: {
 			'focus': '_onFocus',
 			'blur': '_onBlur'
 		},
 		attached: function() {
+			this.addEventListener('focus', this._onFocus, true);
+			this.addEventListener('blur', this._onBlur, true);
 			Polymer.RenderStatus.afterNextRender(this, function() {
 				this._handleSlotChanged();
 				this._slotObserver = Polymer.dom(this.$['dropdown-slot']).observeNodes(this._handleSlotChanged.bind(this));
 			}.bind(this));
 		},
 		detached: function() {
+			this.removeEventListener('focus', this._onFocus);
+			this.removeEventListener('blur', this._onBlur);
 			if (this._slotObserver) {
 				Polymer.dom(this.$['dropdown-slot']).unobserveNodes(this._slotObserver);
 			}

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -252,24 +252,30 @@
 				right: auto;
 			}
 		</style>
-		<div class="d2l-image-tile-image-container">
-			<div class="d2l-image-tile-image-area">
-				<template is="dom-if" if="[[loading]]">
-					<div class="d2l-image-tile-loading-shimmer d2l-image-tile-image"></div>
-				</template>
-				<template is="dom-if" if="[[!loading]]">
-					<slot name="d2l-image-tile-image">
-						<div
-							class="d2l-image-tile-image"
-							style$="[[_getImageStyle(imgUrl)]]"
-						></div>
-					</slot>
-				</template>
+		<div class="container" tabindex="0">
+			<div class="d2l-image-tile-image-container">
+				<div class="d2l-image-tile-image-area">
+					<template is="dom-if" if="[[loading]]">
+						<div class="d2l-image-tile-loading-shimmer d2l-image-tile-image"></div>
+					</template>
+					<template is="dom-if" if="[[!loading]]">
+						<slot name="d2l-image-tile-image">
+							<div
+								class="d2l-image-tile-image"
+								style$="[[_getImageStyle(imgUrl)]]"
+							></div>
+						</slot>
+					</template>
+				</div>
+			</div>
+			<div class="d2l-image-tile-content-container">
+				<slot></slot>
 			</div>
 		</div>
 		<div class="d2l-image-tile-menu-area">
 			<d2l-dropdown on-tap="_onDropdownClick">
 				<d2l-dropdown-more
+					role="button"
 					id="dropdown-more"
 					label="[[dropdownLabel]]"
 					hidden$="[[!_shouldShowMenu(_showMenu, loading)]]">
@@ -283,9 +289,6 @@
 				<slot name="d2l-image-tile-menu-adjacent">
 				</slot>
 			</div>
-		</div>
-		<div class="d2l-image-tile-content-container">
-			<slot></slot>
 		</div>
 	</template>
 	<script>
@@ -341,9 +344,6 @@
 				reflectToAttribute: true
 			},
 			_slotObserver: Object
-		},
-		hostAttributes: {
-			tabindex: 0
 		},
 		listeners: {
 			'focus': '_onFocus',

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -258,6 +258,23 @@
 				right: auto;
 			}
 		</style>
+		<div class="d2l-image-tile-menu-area">
+			<d2l-dropdown on-tap="_onDropdownClick">
+				<d2l-dropdown-more
+					id="dropdown-more"
+					label="[[dropdownLabel]]"
+					hidden$="[[!_shouldShowMenu(_showMenu, loading)]]">
+					<slot name="d2l-image-tile-dropdown"
+						id="dropdown-slot"
+						on-slot-changed="_handleSlotChange">
+					</slot>
+				</d2l-dropdown-more>
+			</d2l-dropdown>
+			<div class="d2l-image-tile-menu-adjacent-container">
+				<slot name="d2l-image-tile-menu-adjacent">
+				</slot>
+			</div>
+		</div>
 		<div class="d2l-image-tile-container" tabindex="0">
 			<div class="d2l-image-tile-image-container">
 				<div class="d2l-image-tile-image-area">
@@ -276,23 +293,6 @@
 			</div>
 			<div class="d2l-image-tile-content-container">
 				<slot></slot>
-			</div>
-		</div>
-		<div class="d2l-image-tile-menu-area">
-			<d2l-dropdown on-tap="_onDropdownClick">
-				<d2l-dropdown-more
-					id="dropdown-more"
-					label="[[dropdownLabel]]"
-					hidden$="[[!_shouldShowMenu(_showMenu, loading)]]">
-					<slot name="d2l-image-tile-dropdown"
-						id="dropdown-slot"
-						on-slot-changed="_handleSlotChange">
-					</slot>
-				</d2l-dropdown-more>
-			</d2l-dropdown>
-			<div class="d2l-image-tile-menu-adjacent-container">
-				<slot name="d2l-image-tile-menu-adjacent">
-				</slot>
 			</div>
 		</div>
 	</template>

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -32,8 +32,6 @@
 				position: relative;
 				text-align: center;
 				width: 350px;
-				display: flex;
-				flex-direction: column-reverse;
 			}
 
 			:host([no-mobile-more-button]) d2l-dropdown-more {

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -146,6 +146,11 @@
 				z-index: 2;
 			}
 
+			.d2l-image-tile-container {
+				height: 100%;
+				border-color: inherit;
+			}
+
 			@keyframes loadingShimmer {
 				0% { transform: translate3d(-100%, 0, 0); }
 				100% { transform: translate3d(100%, 0, 0); }
@@ -252,7 +257,7 @@
 				right: auto;
 			}
 		</style>
-		<div class="container" tabindex="0">
+		<div class="d2l-image-tile-container" tabindex="0">
 			<div class="d2l-image-tile-image-container">
 				<div class="d2l-image-tile-image-area">
 					<template is="dom-if" if="[[loading]]">

--- a/d2l-tile.html
+++ b/d2l-tile.html
@@ -60,12 +60,12 @@
 				opacity: 1;
 			}
 		</style>
-		<template is="dom-if" if="[[href]]">
+		<template is="dom-if" if="[[_hasHref(href)]]">
 			<a class="d2l-tile-content-container" href=[[href]]>
 				<slot></slot>
 			</a>
 		</template>
-		<template is="dom-if" if="[[!href]]">
+		<template is="dom-if" if="[[!_hasHref(href)]]">
 			<div class="d2l-tile-content-container" tabindex="0">
 				<slot></slot>
 			</div>
@@ -113,6 +113,9 @@
 		},
 		_onBlur: function() {
 			this.focused = false;
+		},
+		_hasHref: function(href) {
+			return href !== undefined && href !== null;
 		}
 	});
 	</script>

--- a/d2l-tile.html
+++ b/d2l-tile.html
@@ -28,6 +28,8 @@
 				position: relative;
 				width: 100%;
 				z-index: 2;
+				text-decoration: none;
+				color: black;
 			}
 
 			:host([hover-effect~="low-lift"]) {
@@ -58,10 +60,16 @@
 				opacity: 1;
 			}
 		</style>
-		<div class="d2l-tile-content-container">
-			<div class="d2l-tile-content-container">
-			<slot></slot>
-		</div>
+		<template is="dom-if" if="[[href]]">
+			<a class="d2l-tile-content-container" href=[[href]]>
+				<slot></slot>
+			</a>
+		</template>
+		<template is="dom-if" if="[[!href]]">
+			<div class="d2l-tile-content-container" tabindex="0">
+				<slot></slot>
+			</div>
+		</template>
 	</template>
 	<script>
 	Polymer({
@@ -83,14 +91,22 @@
 				type: Boolean,
 				value: false,
 				reflectToAttribute: true
+			},
+			/**
+			 * A location to go when you click on the tile
+			 */
+			href: {
+				type: String,
+				value: null
 			}
 		},
-		hostAttributes: {
-			tabindex: 0
+		attached: function() {
+			this.addEventListener('focus', this._onFocus, true);
+			this.addEventListener('blur', this._onBlur, true);
 		},
-		listeners: {
-			'focus': '_onFocus',
-			'blur': '_onBlur'
+		detached: function() {
+			this.removeEventListener('focus', this._onFocus);
+			this.removeEventListener('blur', this._onBlur);
 		},
 		_onFocus: function() {
 			this.focused = true;

--- a/d2l-tile.html
+++ b/d2l-tile.html
@@ -61,7 +61,7 @@
 			}
 		</style>
 		<template is="dom-if" if="[[_hasHref(href)]]">
-			<a class="d2l-tile-content-container" href=[[href]]>
+			<a class="d2l-tile-content-container" href$=[[href]]>
 				<slot></slot>
 			</a>
 		</template>

--- a/demo/d2l-image-tile.html
+++ b/demo/d2l-image-tile.html
@@ -150,7 +150,7 @@
 				</template>
 			</demo-snippet>
 
-			<h3>Tile with the CSS background and custom image height</h3>
+			<h3>Tile with the CSS background, custom image height, and a href</h3>
 			<demo-snippet>
 				<template>
 					<custom-style>
@@ -161,7 +161,10 @@
 							}
 						</style>
 					</custom-style>
-					<d2l-image-tile class="style">
+					<d2l-image-tile
+						class="style"
+						href="https://www.google.com"
+					>
 						<p>Tile content</p>
 					</d2l-image-tile>
 				</template>

--- a/demo/d2l-tile.html
+++ b/demo/d2l-tile.html
@@ -20,6 +20,9 @@
 			html {
 				font-size: 20px;
 			}
+			.padding {
+				padding: 3px;
+			}
 		</style>
 	</head>
 	<body unresolved class="d2l-typography">
@@ -38,6 +41,17 @@
 				<template>
 					<d2l-tile hover-effect="low-lift">
 						<p>Tile with Hover State</p>
+					</d2l-tile>
+				</template>
+			</demo-snippet>
+
+			<h3>Tile with link</h3>
+			<demo-snippet>
+				<template>
+					<d2l-tile href="https://www.google.com">
+						<div class="padding">
+							<p>Tile with link</p>
+						</div>
 					</d2l-tile>
 				</template>
 			</demo-snippet>


### PR DESCRIPTION
Aria shouldn't read out both the menu and the tile content when you just focus the tile

based off: https://github.com/BrightspaceUI/tile/pull/47

### What is this all?
NVDA was reading out the menu when you focused on the tile, since it was inside the focused area
I moved it out of the focused area, but that broke v0 slot order (default slot needs to be last)
I tried reversing the menu and tile, but that broke tab order

I didn't want to muck up the api by making the default tile content into a named slot, so I created a "base image tile" element with named slots in the right order.

This made it easy to also add in "href" functionality which was needed for non-SPA's (my-courses tiles are links, not buttons)

While testing things out I found out that the focus listeners were no longer working in 1.x with this setup, so I changed them back to what they were before (but added in remove listener scripts)