### PR TITLE
Use ferrite instead of black

### DIFF
--- a/d2l-image-tile-base.html
+++ b/d2l-image-tile-base.html
@@ -8,7 +8,7 @@
 			}
 
 			.d2l-image-tile-base-link {
-				color: black;
+				color: var(--d2l-color-ferrite);
 				text-decoration: none;
 				border-color: inherit;
 			}

--- a/d2l-image-tile-base.html
+++ b/d2l-image-tile-base.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../d2l-colors/d2l-colors.html">
 
 <dom-module id="d2l-image-tile-base">
 	<template strip-whitespace>

--- a/d2l-tile.html
+++ b/d2l-tile.html
@@ -29,7 +29,7 @@
 				width: 100%;
 				z-index: 2;
 				text-decoration: none;
-				color: black;
+				color: var(--d2l-color-ferrite);
 			}
 
 			:host([hover-effect~="low-lift"]) {


### PR DESCRIPTION
This matches our normal styling, which defaults to using ferrite instead of black for text. If needed, this could be changed via a CSS property, but YAGNI for now (unless there's already a need for it that I'm not aware of, in which case I'll add it).