### PR TITLE
Dbatiste/hybrid cleanup

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "d2l-colors": "^3.1.2",
-    "d2l-dropdown": "^6.0.0",
+    "d2l-dropdown": "^6.0.10",
     "polymer": "1 - 2"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -22,12 +22,11 @@
     "polymer": "1 - 2"
   },
   "devDependencies": {
+    "d2l-menu": "^1.0.4",
     "d2l-typography": "^6.0.8",
     "iron-component-page": "^2.0.0",
     "iron-demo-helpers": "^2.0.0",
-    "webcomponentsjs": "^1.0.0",
-    "web-component-tester": "^6.5.0",
-    "d2l-menu": "^1.0.4"
+    "web-component-tester": "^6.5.0"
   },
   "variants": {
     "1.x": {
@@ -38,5 +37,8 @@
         "webcomponentsjs": "^0.7"
       }
     }
+  },
+  "resolutions": {
+    "webcomponentsjs": "^v1.0.0"
   }
 }

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -368,9 +368,9 @@
 			'blur': '_onBlur'
 		},
 		attached: function() {
-			this.addEventListener('focus', this._onFocus, true);
-			this.addEventListener('blur', this._onBlur, true);
 			Polymer.RenderStatus.afterNextRender(this, function() {
+				this.addEventListener('focus', this._onFocus, true);
+				this.addEventListener('blur', this._onBlur, true);
 				this._handleSlotChanged();
 				this._slotObserver = Polymer.dom(this.$['dropdown-slot']).observeNodes(this._handleSlotChanged.bind(this));
 			}.bind(this));

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -40,7 +40,7 @@
 				pointer-events: none;
 			}
 
-			:host([no-mobile-more-button][hover-effect~="lower-menu"]:not(:hover):not([focused]):not([menu-opened])) d2l-dropdown {
+			:host([no-mobile-more-button][hover-effect~="lower-menu"]:not(:hover):not([focused]):not([menu-opened])) d2l-dropdown-more {
 				margin-top: -15px;
 			}
 
@@ -78,23 +78,23 @@
 				width: 100%;
 			}
 
-			d2l-dropdown {
+			d2l-dropdown-more {
 				margin: 0 15px 15px 15px;
 				right: 0;
 				top: 0;
 				transition: margin-top .25s;
 			}
 
-			:host([hover-effect~="lower-menu"]:not(:hover):not([focused]):not([menu-opened])) d2l-dropdown {
+			:host([hover-effect~="lower-menu"]:not(:hover):not([focused]):not([menu-opened])) d2l-dropdown-more {
 				margin-top: -15px;
 			}
 
-			:host-context([dir="rtl"]) d2l-dropdown {
+			:host-context([dir="rtl"]) d2l-dropdown-more {
 				left: 0;
 				right: auto;
 			}
 
-			:host(:dir(rtl)) d2l-dropdown {
+			:host(:dir(rtl)) d2l-dropdown-more {
 				left: 0;
 				right: auto;
 			}
@@ -104,7 +104,7 @@
 			}
 
 			@media only screen and (hover: hover), only screen and (-moz-touch-enabled: 0) {
-				:host([hover-effect~="lower-menu"]:not(:hover):not([focused]):not([menu-opened])) d2l-dropdown {
+				:host([hover-effect~="lower-menu"]:not(:hover):not([focused]):not([menu-opened])) d2l-dropdown-more {
 					margin-top: -15px;
 				}
 
@@ -261,17 +261,16 @@
 		</style>
 		<d2l-image-tile-base href="[[href]]">
 			<div class="d2l-image-tile-menu-area" slot="d2l-image-tile-base-menu-area">
-				<d2l-dropdown on-tap="_onDropdownClick">
-					<d2l-dropdown-more
-						id="dropdown-more"
-						label="[[dropdownLabel]]"
-						hidden$="[[!_shouldShowMenu(_showMenu, loading)]]">
-						<slot name="d2l-image-tile-dropdown"
-							id="dropdown-slot"
-							on-slot-changed="_handleSlotChange">
-						</slot>
-					</d2l-dropdown-more>
-				</d2l-dropdown>
+				<d2l-dropdown-more
+					on-tap="_onDropdownClick"
+					id="dropdown-more"
+					label="[[dropdownLabel]]"
+					hidden$="[[!_shouldShowMenu(_showMenu, loading)]]">
+					<slot name="d2l-image-tile-dropdown"
+						id="dropdown-slot"
+						on-slot-changed="_handleSlotChange">
+					</slot>
+				</d2l-dropdown-more>
 				<div class="d2l-image-tile-menu-adjacent-container">
 					<slot name="d2l-image-tile-menu-adjacent">
 					</slot>

--- a/d2l-tile-behavior.html
+++ b/d2l-tile-behavior.html
@@ -1,6 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
 <script>
-
 	window.D2L = window.D2L || {};
 	window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
 

--- a/d2l-tile-behavior.html
+++ b/d2l-tile-behavior.html
@@ -1,10 +1,15 @@
 <link rel="import" href="../polymer/polymer.html">
 <script>
-	/* @polymerBehavior D2L.PolymerBehaviors.TileBehavior */
-	var TileBehaviorImpl = {
+
+	window.D2L = window.D2L || {};
+	window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
+
+	/* @polymerBehavior */
+	D2L.PolymerBehaviors.TileBehavior = {
+
 		properties: {
 			/**
-			* A boolean that is true if the tile menu is open, otherwise false
+			* Indicates whether the menu is open.
 			*/
 			menuOpened: {
 				type: Boolean,
@@ -13,19 +18,20 @@
 				reflectToAttribute: true
 			}
 		},
+
 		listeners: {
 			'd2l-dropdown-open': '_onMenuOpen',
 			'd2l-dropdown-close': '_onMenuClose'
 		},
+
 		_onMenuOpen: function() {
 			this.menuOpened = true;
 		},
+
 		_onMenuClose: function() {
 			this.menuOpened = false;
 		}
+
 	};
 
-	window.D2L = window.D2L || {};
-	window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
-	D2L.PolymerBehaviors.TileBehavior = TileBehaviorImpl;
 </script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-tile",
-  "description": "Brightspace Tile",
+  "description": "Polymer-based web components for D2L tiles.",
   "private": true,
   "scripts": {
     "postinstall": "polymer install --variants",


### PR DESCRIPTION
@jstefaniuk-d2l / @ryantmer : I removed a `d2l-dropdown` that should not be necessary.  It would be great to get your "ok" on this, since it looks like there is some special behavior with this component.  Also I updated to newer version of `d2l-dropdown` to avoid a JS error that I observed in Safari on page-load due to it not finding a parent opener component.

The general syntax is to look like:
```
<opener>  // d2l-dropdown / d2l-dropdown-button / d2l-dropdown-context-menu / d2l-dropdown-more
   <content> // d2l-dropdown-content / d2l-dropdown-menu
      // some generic HTML or a d2l-menu
   <content> 
</opener>
```

The `d2l-dropdown` opener is a little special in that it supports a generic opener which will look for another child element denoted by `class="d2l-dropdown-opener"`.  Ideally we just stick with the built-in openers `-button`, `-context-menu`, `-more` for consistency, which this component was doing, but strangely was being wrapped in a 2nd opener.