### PR TITLE
inherit bottom border color, add specifiedTabIndex property

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Include the [webcomponents.js](http://webcomponents.org/polyfills/) "lite" polyf
 #### Making the tile into a link:
 You can make the tile into a link by passing in a `href` property
 
+#### Tab Index
+You can specify the `tabindex` of the tile using the `specified-tab-index` property (default 0)
+
 ### d2l-image-tile
 
 An extension of `<d2l-tile>`, `<d2l-image-tile>` adds an image at the top, content at the bottom, and an optional `...` "more" menu which can launch a [d2l-dropdown-menu](https://github.com/BrightspaceUI/dropdown#menu-content).
@@ -140,7 +143,10 @@ Alternatively, you can provide custom image content in the `d2l-image-tile-image
 ```
 
 #### Making the image tile into a link:
-You can make the tile into a link by passing in a `href` property and the `specified-tab-index` can be used to specify the tabindex of the tile (default 0)
+You can make the tile into a link by passing in a `href` property
+
+#### Tab Index
+You can specify the `tabindex` of the tile using the `specified-tab-index` property (default 0)
 
 #### "More" menu
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Alternatively, you can provide custom image content in the `d2l-image-tile-image
 ```
 
 #### Making the image tile into a link:
-You can make the tile into a link by passing in a `href` property
+You can make the tile into a link by passing in a `href` property and the `specified-tab-index` can be used to specify the tabindex of the tile (default 0)
 
 #### "More" menu
 

--- a/d2l-image-tile-base.html
+++ b/d2l-image-tile-base.html
@@ -19,7 +19,7 @@
 			}
 		</style>
 		<template is="dom-if" if="href=[[_hasHref(href)]]">
-			<a class="d2l-image-tile-base-link" href$=[[href]]>
+			<a class="d2l-image-tile-base-link" href$=[[href]] tabindex$=[[specifiedTabIndex]]>
 				<slot name="d2l-image-tile-base-content"></slot>
 			</a>
 		</template>

--- a/d2l-image-tile-base.html
+++ b/d2l-image-tile-base.html
@@ -24,7 +24,7 @@
 			</a>
 		</template>
 		<template is="dom-if" if="[[!_hasHref(href)]]">
-			<div class="d2l-image-tile-base-div" tabindex="0">
+			<div class="d2l-image-tile-base-div" tabindex$=[[specifiedTabIndex]]>
 				<slot name="d2l-image-tile-base-content"></slot>
 			</div>
 		</template>
@@ -37,6 +37,10 @@
 			href: {
 				type: String,
 				value: null
+			},
+			specifiedTabIndex: {
+				type: String,
+				value: "0"
 			}
 		},
 		_hasHref: function(href) {

--- a/d2l-image-tile-base.html
+++ b/d2l-image-tile-base.html
@@ -40,7 +40,7 @@
 			},
 			specifiedTabIndex: {
 				type: String,
-				value: "0"
+				value: '0'
 			}
 		},
 		_hasHref: function(href) {

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -367,7 +367,7 @@
 			**/
 			specifiedTabIndex: {
 				type: String,
-				value: "0"
+				value: '0'
 			}
 		},
 		listeners: {

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -52,7 +52,8 @@
 			}
 
 			.d2l-image-tile-image-container {
-				border-bottom: 1px solid;
+				border-bottom-width: inherit;
+				border-bottom-style: solid;
 				border-bottom-color: inherit;
 				border-top-left-radius: 6px;
 				border-top-right-radius: 6px;
@@ -259,7 +260,7 @@
 				right: auto;
 			}
 		</style>
-		<d2l-image-tile-base href="[[href]]">
+		<d2l-image-tile-base href="[[href]]" specified-tab-index$="[[specifiedTabIndex]]">
 			<div class="d2l-image-tile-menu-area" slot="d2l-image-tile-base-menu-area">
 				<d2l-dropdown-more
 					on-tap="_onDropdownClick"
@@ -360,6 +361,13 @@
 			href: {
 				type: String,
 				value: null
+			},
+			/**
+			 * tabindex within the tile
+			**/
+			specifiedTabIndex: {
+				type: String,
+				value: "0"
 			}
 		},
 		listeners: {

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -260,7 +260,7 @@
 				right: auto;
 			}
 		</style>
-		<d2l-image-tile-base href="[[href]]" specified-tab-index$="[[specifiedTabIndex]]">
+		<d2l-image-tile-base href="[[href]]" specified-tab-index="[[specifiedTabIndex]]">
 			<div class="d2l-image-tile-menu-area" slot="d2l-image-tile-base-menu-area">
 				<d2l-dropdown-more
 					on-tap="_onDropdownClick"

--- a/d2l-tile.html
+++ b/d2l-tile.html
@@ -61,12 +61,12 @@
 			}
 		</style>
 		<template is="dom-if" if="[[_hasHref(href)]]">
-			<a class="d2l-tile-content-container" href$=[[href]]>
+			<a class="d2l-tile-content-container" href$=[[href]] tabindex$=[[specifiedTabIndex]]>
 				<slot></slot>
 			</a>
 		</template>
 		<template is="dom-if" if="[[!_hasHref(href)]]">
-			<div class="d2l-tile-content-container" tabindex="0">
+			<div class="d2l-tile-content-container" tabindex$=[[specifiedTabIndex]]>
 				<slot></slot>
 			</div>
 		</template>
@@ -98,6 +98,13 @@
 			href: {
 				type: String,
 				value: null
+			},
+			/**
+			 * tabindex within the tile
+			**/
+			specifiedTabIndex: {
+				type: String,
+				value: '0'
 			}
 		},
 		attached: function() {


### PR DESCRIPTION
changes needed in order to be able to use `d2l-image-tile` within activity details. PR https://github.com/Brightspace/d2l-activity-details-ui/pull/25