### PR TITLE
Remove z-index: 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Both `<d2l-tile>` and `<d2l-image-tile>` support setting an effect for when the 
 
 ### What if I want something partially overlapping the image???
 
-Stick it at the top of the content area and give it a negative top margin.
+Stick it in the `d2l-image-tile-image` slot along with the image and an offset.
 
 ### What if I want to make the tile clickable, but have another clickable element within
 

--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -247,7 +247,6 @@
 				top: 0;
 				margin-top: 15px;
 				display: flex;
-				z-index: 3;
 			}
 
 			:host-context([dir="rtl"]) .d2l-image-tile-menu-area {


### PR DESCRIPTION
This was causing a bug in My Courses where a course tile's menu could end up underneath a different course's menu. This z-index was added in the first place to fix a different problem there, but another change allows us to avoid the circumstance altogether, removing the need for this z-index.

Effectively a revert of https://github.com/BrightspaceUI/tile/pull/48/commits/9b75c3254bfe7c26f63e97adbb5697139743ecd2