### PR TITLE
Fix more "..." menu not displaying in IE11

### DIFF
--- a/d2l-image-tile.html
+++ b/d2l-image-tile.html
@@ -104,7 +104,7 @@
 				transition: color .5s, background .5s, opacity .25s;
 			}
 
-			@media only screen and (hover: hover), only screen and (-moz-touch-enabled: 0) {
+			@media only screen and (hover: hover), only screen and (-moz-touch-enabled: 0), all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
 				:host([hover-effect~="lower-menu"]:not(:hover):not([focused]):not([menu-opened])) d2l-dropdown-more {
 					margin-top: -15px;
 				}


### PR DESCRIPTION
The part I added is supposed to work on IE10 and 11 only.  The original media query did not working on IE11.  Perhaps someone on a Surface using IE11 could run into a problem with this overall?  But... why.?