### PR TITLE
DE30421 Fix if condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: node
+node_js: 9
 script:
 - npm run lint
 - polymer test --skip-plugin local

--- a/d2l-image-tile-base.html
+++ b/d2l-image-tile-base.html
@@ -18,7 +18,7 @@
 				border-color: inherit;
 			}
 		</style>
-		<template is="dom-if" if="href=[[_hasHref(href)]]">
+		<template is="dom-if" if="[[_hasHref(href)]]">
 			<a class="d2l-image-tile-base-link" href$=[[href]] tabindex$=[[specifiedTabIndex]]>
 				<slot name="d2l-image-tile-base-content"></slot>
 			</a>

--- a/test/d2l-image-tile-base.html
+++ b/test/d2l-image-tile-base.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-image-tile-base tests</title>
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../web-component-tester/browser.js"></script>
+		<link rel="import" href="../d2l-image-tile-base.html">
+	</head>
+	<body>
+		<test-fixture id="image-tile-base">
+			<template>
+				<d2l-image-tile-base></d2l-image-tile-base>
+			</template>
+		</test-fixture>
+		<script>
+			describe('d2l-image-tile-base', () => {
+				var component;
+
+				beforeEach(() => {
+					component = fixture('image-tile-base');
+				});
+
+				it('should instantiate the component', () => {
+					expect(component.is).to.equal('d2l-image-tile-base');
+				});
+
+				describe('Public API', () => {
+					describe('href', () => {
+						it('should render an anchor element when href is set', () => {
+							component.href = 'https://example.com/';
+
+							Polymer.dom.flush();
+
+							var anchor = component.$$('a');
+
+							expect(anchor).to.not.be.null;
+							expect(anchor.href).to.equal('https://example.com/');
+						});
+
+						it('should render a div element when href is not set', () => {
+							component.href = null;
+
+							Polymer.dom.flush();
+
+							var div = component.$$('div');
+							expect(div).to.not.be.null;
+						});
+					});
+
+					describe('specifiedTabIndex', () => {
+						it('should set the tabindex on the anchor element', () => {
+							component.href = 'https://example.com/';
+							component.specifiedTabIndex = 5;
+
+							Polymer.dom.flush();
+
+							expect(component.$$('a').getAttribute('tabindex')).to.equal('5');
+						});
+
+						it('should set the tabindex on the anchor element', () => {
+							component.specifiedTabIndex = 5;
+
+							Polymer.dom.flush();
+
+							expect(component.$$('div').getAttribute('tabindex')).to.equal('5');
+						});
+					});
+				});
+			});
+		</script>
+	</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -7,12 +7,19 @@
 	</head>
 	<body>
 		<script>
-			WCT.loadSuites([
-				'd2l-tile.html?wc-shadydom=true&wc-ce=true',
-				'd2l-tile.html?dom=shadow',
-				'd2l-image-tile.html?wc-shadydom=true&wc-ce=true',
-				'd2l-image-tile.html?dom=shadow'
-			]);
+			var files = [
+				'd2l-tile.html',
+				'd2l-image-tile.html',
+				'd2l-image-tile-base.html'
+			];
+
+			var tests = [];
+			files.forEach(file => {
+				tests.push(file + '?wc-shadydom=true');
+				tests.push(file + '?dom=shadow');
+			});
+
+			WCT.loadSuites(tests);
 		</script>
 	</body>
 </html>


### PR DESCRIPTION
Found while fixing DE30421, although not strictly related to it. The typo in the `if` condition here meant that even if `href` was null or undefined, the `d2l-image-tile` would always render the `<a>`. This caused weird tabbing behaviour, as the focus would move to an anchor without an href, which doesn't really make a whole lot of sense.