### PR TITLE
Add restamp

### DIFF
--- a/d2l-image-tile-base.html
+++ b/d2l-image-tile-base.html
@@ -18,12 +18,12 @@
 				border-color: inherit;
 			}
 		</style>
-		<template is="dom-if" if="[[_hasHref(href)]]">
+		<template is="dom-if" if="[[_hasHref(href)]]" restamp="true">
 			<a class="d2l-image-tile-base-link" href$=[[href]] tabindex$=[[specifiedTabIndex]]>
 				<slot name="d2l-image-tile-base-content"></slot>
 			</a>
 		</template>
-		<template is="dom-if" if="[[!_hasHref(href)]]">
+		<template is="dom-if" if="[[!_hasHref(href)]]" restamp="true">
 			<div class="d2l-image-tile-base-div" tabindex$=[[specifiedTabIndex]]>
 				<slot name="d2l-image-tile-base-content"></slot>
 			</div>


### PR DESCRIPTION
When switching the value of `href` non-null to null, the dom-if containing a div doesn't render. Adding `restamp="true"` fixes this.