### PR TITLE
Initial card layout.

### DIFF
--- a/d2l-card.html
+++ b/d2l-card.html
@@ -23,7 +23,7 @@ Polymer-based web components for card
 			.d2l-card-content {
 				padding: 1.5rem 1.2rem;
 			}
-			.d2l-card-footer {
+			.d2l-card-footer[has-footer] {
 				padding: 0.6rem 1.2rem;
 			}
 			:host([subtle]) {
@@ -49,6 +49,20 @@ Polymer-based web components for card
 					type: Boolean
 				}
 
+			},
+
+			attached: function() {
+				this.listen(this.$$('.d2l-card-footer slot'), 'slotchange', '_onSlotChange');
+			},
+
+			detached: function() {
+				this.unlisten(this.$$('.d2l-card-footer slot'), 'slotchange', '_onSlotChange');
+			},
+
+			_onSlotChange: function() {
+				this.$$('.d2l-card-footer slot').assignedNodes().length > 0
+					? this.$$('.d2l-card-footer').setAttribute('has-footer', true)
+					: this.$$('.d2l-card-footer').removeAttribute('has-footer');
 			}
 
 		});

--- a/d2l-card.html
+++ b/d2l-card.html
@@ -1,0 +1,57 @@
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../d2l-colors/d2l-colors.html">
+
+<!--
+`d2l-card`
+Polymer-based web components for card
+
+@demo demo/d2l-card.html
+-->
+
+<dom-module id="d2l-card">
+
+	<template strip-whitespace>
+		<style>
+			:host {
+				background-color: #ffffff;
+				border: 1px solid var(--d2l-color-gypsum);
+				border-radius: 6px;
+				box-sizing: border-box;
+				display: inline-block;
+				overflow: hidden;
+			}
+			.d2l-card-content {
+				padding: 1.5rem 1.2rem;
+			}
+			.d2l-card-footer {
+				padding: 0.6rem 1.2rem;
+			}
+			:host([subtle]) {
+				border-color: transparent;
+				box-shadow: 0 4px 8px 0 rgba(0,0,0,0.03);
+			}
+		</style>
+		<div class="d2l-card-header"><slot name="header"></slot></div>
+		<div class="d2l-card-content"><slot></slot></div>
+		<div class="d2l-card-footer"><slot name="footer"></slot></div>
+	</template>
+
+	<script>
+		Polymer({
+			is: 'd2l-card',
+
+			properties: {
+
+				/**
+				 * Indicates whether subtle container style should be applied (for non-white backgrounds).
+				 */
+				subtle: {
+					type: Boolean
+				}
+
+			}
+
+		});
+	</script>
+
+</dom-module>

--- a/demo/d2l-card.html
+++ b/demo/d2l-card.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-card demo</title>
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+		<link rel="import" href="../../polymer/polymer.html">
+		<link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
+		<link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+		<link rel="import" href="../../d2l-typography/d2l-typography.html">
+		<link rel="import" href="../d2l-card.html">
+		<custom-style>
+			<style is="custom-style" include="demo-pages-shared-styles"></style>
+		</custom-style>
+		<custom-style include="d2l-typography">
+			<style is="custom-style" include="d2l-typography"></style>
+		</custom-style>
+		<style>
+			html {
+				font-size: 20px;
+			}
+			.subtle-demo {
+				background-color: #f6f7f8;
+				margin: -20px;
+				padding: 20px;
+			}
+		</style>
+	</head>
+	<body unresolved class="d2l-typography">
+		<div class="vertical-section-container centered">
+
+			<h3>Card</h3>
+
+			<demo-snippet>
+				<template>
+					<div class="subtle-demo">
+					<d2l-card subtle>
+						<div slot="header">
+							<img style="width: 300px; height: 150px;" src="https://www.nasa.gov/sites/default/files/thumbnails/image/pia21970-opt.jpg" />
+						</div>
+						<div>
+							Jupiter
+						</div>
+						<div slot="footer">Secondary Actions</div>
+					</d2l-card>
+				</template>
+			</demo-snippet>
+
+		</div>
+		<script>
+
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
Basic shell only for now - I assume there is more to do here, but this unblocks a few stories, so worth merging and starting to use it. In particular, the `d2l-course-image-tile` will be converted to use a `d2l-card`  instead of the current `d2l-image-tile`.