### PR TITLE
Dbatiste/card layout

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "brightspace/polymer-config"
+  "extends": "brightspace/polymer-config",
+  "globals": {
+    "fastdom": false
+  }
 }

--- a/bower.json
+++ b/bower.json
@@ -19,9 +19,13 @@
   "dependencies": {
     "d2l-colors": "^3.1.2",
     "d2l-dropdown": "^6.0.10",
+    "d2l-fastdom-import": "https://github.com/Brightspace/fastdom-import.git#v1.0.2",
+    "d2l-link": "^4.0.2",
+    "d2l-polymer-behaviors": "^1.6.2",
     "polymer": "1 - 2"
   },
   "devDependencies": {
+    "d2l-button": "^4.6.0",
     "d2l-menu": "^1.0.4",
     "d2l-typography": "^6.0.8",
     "iron-component-page": "^2.0.0",

--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
     "d2l-dropdown": "^6.0.10",
     "d2l-fastdom-import": "https://github.com/Brightspace/fastdom-import.git#v1.0.2",
     "d2l-link": "^4.0.2",
+    "d2l-offscreen": "^3.0.3",
     "d2l-polymer-behaviors": "^1.6.2",
     "polymer": "1 - 2"
   },

--- a/bower.json
+++ b/bower.json
@@ -23,11 +23,13 @@
     "d2l-link": "^4.0.2",
     "d2l-offscreen": "^3.0.3",
     "d2l-polymer-behaviors": "^1.6.2",
+    "d2l-resize-observer-polyfill-import": "https://github.com/Brightspace/resize-observer-polyfill-import.git#4101abe201c413a4255be22095c05e0e2f562313",
     "polymer": "1 - 2"
   },
   "devDependencies": {
     "d2l-button": "^4.6.0",
     "d2l-menu": "^1.0.4",
+    "d2l-status-indicator": "^2.0.0",
     "d2l-typography": "^6.0.8",
     "iron-component-page": "^2.0.0",
     "iron-demo-helpers": "^2.0.0",

--- a/d2l-card-content-meta.html
+++ b/d2l-card-content-meta.html
@@ -17,7 +17,7 @@ Polymer-based web component for card meta-data
 				color: var(--d2l-color-tungsten);
 				font-size: 0.7rem;
 				font-weight: 400;
-				display: block;
+				display: inline-block;
 				line-height: 1rem;
 			}
 		</style>

--- a/d2l-card-content-meta.html
+++ b/d2l-card-content-meta.html
@@ -1,0 +1,33 @@
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../d2l-colors/d2l-colors.html">
+
+<!--
+`d2l-card-content-meta`
+Polymer-based web component for card meta-data
+
+@demo demo/d2l-card.html
+-->
+
+<dom-module id="d2l-card-content-meta">
+
+	<template strip-whitespace>
+		<style>
+			:host {
+				box-sizing: border-box;
+				color: var(--d2l-color-tungsten);
+				font-size: 0.7rem;
+				font-weight: 400;
+				display: block;
+				line-height: 1rem;
+			}
+		</style>
+		<slot></slot>
+	</template>
+
+	<script>
+		Polymer({
+			is: 'd2l-card-content-meta'
+		});
+	</script>
+
+</dom-module>

--- a/d2l-card-content-title.html
+++ b/d2l-card-content-title.html
@@ -1,0 +1,32 @@
+<link rel="import" href="../polymer/polymer.html">
+
+<!--
+`d2l-card-content-title`
+Polymer-based web component for card title
+
+@demo demo/d2l-card.html
+-->
+
+<dom-module id="d2l-card-content-title">
+
+	<template strip-whitespace>
+		<style>
+			:host {
+				box-sizing: border-box;
+				font-size: 0.95rem;
+				font-weight: 400;
+				display: block;
+				line-height: 1.4rem;
+				text-align: center;
+			}
+		</style>
+		<slot></slot>
+	</template>
+
+	<script>
+		Polymer({
+			is: 'd2l-card-content-title'
+		});
+	</script>
+
+</dom-module>

--- a/d2l-card.html
+++ b/d2l-card.html
@@ -5,6 +5,7 @@
 <link rel="import" href="../d2l-offscreen/d2l-offscreen-shared-styles.html">
 <link rel="import" href="../d2l-polymer-behaviors/d2l-dom.html">
 <link rel="import" href="../d2l-polymer-behaviors/d2l-focusable-behavior.html">
+<link rel="import" href="../d2l-resize-observer-polyfill-import/resize-observer.html">
 
 <!--
 `d2l-card`
@@ -154,7 +155,7 @@ Polymer-based web components for card
 			},
 
 			ready: function() {
-				this._onBadgeChanges = this._onBadgeChanges.bind(this);
+				this._onBadgeResize = this._onBadgeResize.bind(this);
 				this._onFooterChanges = this._onFooterChanges.bind(this);
 				this._onLinkBlur = this._onLinkBlur.bind(this);
 				this._onLinkFocus = this._onLinkFocus.bind(this);
@@ -163,7 +164,8 @@ Polymer-based web components for card
 			attached: function() {
 				var badge = Polymer.dom(this.root).querySelector('.d2l-card-badge');
 				var footer = Polymer.dom(this.root).querySelector('.d2l-card-footer');
-				this._badgeObserver = Polymer.dom(badge).observeNodes(this._onBadgeChanges);
+				this._badgeObserver = new ResizeObserver(this._onBadgeResize);
+				this._badgeObserver.observe(badge);
 				this._footerObserver = Polymer.dom(footer).observeNodes(this._onFooterChanges);
 				Polymer.RenderStatus.afterNextRender(this, function() {
 					var link = Polymer.dom(this.root).querySelector('a');
@@ -175,23 +177,20 @@ Polymer-based web components for card
 			detached: function() {
 				var badge = Polymer.dom(this.root).querySelector('.d2l-card-badge');
 				var footer = Polymer.dom(this.root).querySelector('.d2l-card-footer');
-				if (this._badgeObserver) Polymer.dom(badge).unobserveNodes(this._badgeObserver);
+				if (this._badgeObserver) this._badgeObserver.unobserve(badge);
 				if (this._footerObserver) Polymer.dom(footer).unobserveNodes(this._footerObserver);
 				var link = Polymer.dom(this.root).querySelector('a');
 				link.removeEventListener('blur', this._onLinkBlur);
 				link.removeEventListener('focus', this._onLinkFocus);
 			},
 
-			_onBadgeChanges: function(data) {
-				var elems = this.getEffectiveChildren();
-				if (!elems || elems.length === 0) {
+			_onBadgeResize: function(entries) {
+				if (!entries || entries.length === 0) {
 					return;
 				}
-				fastdom.measure(function() {
-					var height = data.target.getBoundingClientRect().height;
-					fastdom.mutate(function() {
-						data.target.style.marginTop = (-0.5 * height) + 'px';
-					});
+				var entry = entries[0];
+				fastdom.mutate(function() {
+					entry.target.style.marginTop = (-0.5 * entry.contentRect.height) + 'px';
 				});
 			},
 

--- a/d2l-card.html
+++ b/d2l-card.html
@@ -144,7 +144,7 @@ Polymer-based web components for card
 				},
 
 				/**
-				 * Accessible text for the link.
+				 * Accessible text for the link (not visible, gets announced when user focuses on card).
 				 */
 				text: {
 					type: String,

--- a/d2l-card.html
+++ b/d2l-card.html
@@ -108,7 +108,7 @@ Polymer-based web components for card
 		</style>
 		<div class="d2l-card-container">
 			<div class="d2l-card-link-container">
-				<a class="d2l-focusable" aria-label="Jovian" download$="[[download]]" href$="[[href]]" hreflang="[[hreflang]]" rel="[[rel]]" target="[[target]]" type="[[type]]">
+				<a class="d2l-focusable" download$="[[download]]" href$="[[href]]" hreflang="[[hreflang]]" rel="[[rel]]" target="[[target]]" type="[[type]]">
 					<span class="d2l-card-link-text">[[text]]</span>
 				</a>
 				<div class="d2l-card-header"><slot name="header"></slot></div>

--- a/d2l-card.html
+++ b/d2l-card.html
@@ -212,11 +212,15 @@ Polymer-based web components for card
 			},
 
 			_onLinkBlur: function() {
-				this.removeAttribute('active', 'active');
+				fastdom.mutate(function() {
+					this.removeAttribute('active', 'active');
+				}.bind(this));
 			},
 
 			_onLinkFocus: function() {
-				this.setAttribute('active', 'active');
+				fastdom.mutate(function() {
+					this.setAttribute('active', 'active');
+				}.bind(this));
 			}
 
 		});

--- a/d2l-card.html
+++ b/d2l-card.html
@@ -31,9 +31,11 @@ Polymer-based web components for card
 				height: 100%;
 			}
 			a {
+				color: var(--d2l-color-ferrite);
 				display: block;
 				flex: 1;
 				outline: none;
+				text-decoration: none;
 			}
 			.d2l-card-content {
 				padding: 1.5rem 1.2rem;
@@ -88,9 +90,15 @@ Polymer-based web components for card
 				box-shadow: 0 0 0 4px rgba(0, 111, 191, 0.3);
 				transform: translateY(-4px);
 			}
+
+			:host .d2l-card-actions ::slotted(d2l-button-icon) {
+				--d2l-button-icon-min-height: 1.8rem;
+				--d2l-button-icon-min-width: 1.8rem;
+			}
+
 		</style>
 		<div class="d2l-card-container">
-			<a class="d2l-focusable" download$="[[download]]" href$="[[href]]" hreflang="[[hreflang]]" rel="[[rel]]" target="[[target]]" type="[[type]]">
+			<a class="d2l-focusable" aria-label="Jovian" download$="[[download]]" href$="[[href]]" hreflang="[[hreflang]]" rel="[[rel]]" target="[[target]]" type="[[type]]">
 				<div class="d2l-card-header"><slot name="header"></slot></div>
 				<div class="d2l-card-badge"><slot name="badge"></slot></div>
 				<div class="d2l-card-content"><slot name="content"></slot></div>

--- a/d2l-card.html
+++ b/d2l-card.html
@@ -1,5 +1,9 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
+<link rel="import" href="../d2l-fastdom-import/fastdom.html">
+<link rel="import" href="../d2l-link/d2l-link-behavior.html">
+<link rel="import" href="../d2l-polymer-behaviors/d2l-dom.html">
+<link rel="import" href="../d2l-polymer-behaviors/d2l-focusable-behavior.html">
 
 <!--
 `d2l-card`
@@ -17,30 +21,97 @@ Polymer-based web components for card
 				border: 1px solid var(--d2l-color-gypsum);
 				border-radius: 6px;
 				box-sizing: border-box;
+				display: inline-block;
+				overflow: hidden;
+			}
+			.d2l-card-container {
 				display: flex;
 				flex-direction: column;
-				overflow: hidden;
+				position: relative;
+				height: 100%;
+			}
+			a {
+				display: block;
+				flex: 1;
+				outline: none;
 			}
 			.d2l-card-content {
 				padding: 1.5rem 1.2rem;
-				flex-grow: 1;
 			}
-			.d2l-card-footer ::slotted([slot=footer]) {
-				padding: 0.6rem 1.2rem;
+			.d2l-card-actions {
+				position: absolute;
+				right: 0.6rem;
+				top: 0.6rem;
+			}
+			/* P2-shadow */
+			:host-context([dir="rtl"]) .d2l-card-actions {
+				left: 0.6rem;
+				right: auto;
+			}
+			/* P1-shady, P2-shady */
+			:host(:dir(rtl)) .d2l-card-actions {
+				left: 0.6rem;
+				right: auto;
+			}
+			.d2l-card-badge {
+				line-height: 0;
+				text-align: center;
+			}
+			.d2l-card-footer {
+				display: none;
+				flex: none;
+				padding: 0 1.2rem;
+			}
+			.d2l-card-footer[shown] {
+				display: block;
+			}
+			.d2l-card-footer-content {
+				border-top: 1px solid var(--d2l-color-gypsum);
+				padding: 0.6rem 0;
 			}
 			:host([subtle]) {
 				border-color: transparent;
 				box-shadow: 0 4px 8px 0 rgba(0,0,0,0.03);
+				-webkit-transition: transform 300ms ease-out;
+				transition: transform 300ms ease-out 50ms;
+			}
+			:host([subtle]:hover) {
+				box-shadow: 0 4px 18px 2px rgba(0,0,0,0.06);
+				transform: translateY(-4px);
+			}
+			:host([active]) {
+				border-color: rgba(0, 111, 191, 0.4);
+				box-shadow: 0 0 0 4px rgba(0, 111, 191, 0.3);
+			}
+			:host([subtle][active]:hover) {
+				border-color: rgba(0, 111, 191, 0.4);
+				box-shadow: 0 0 0 4px rgba(0, 111, 191, 0.3);
+				transform: translateY(-4px);
 			}
 		</style>
-		<div class="d2l-card-header"><slot name="header"></slot></div>
-		<div class="d2l-card-content"><slot name="content"></slot></div>
-		<div class="d2l-card-footer"><slot name="footer"></slot></div>
+		<div class="d2l-card-container">
+			<a class="d2l-focusable" download$="[[download]]" href$="[[href]]" hreflang="[[hreflang]]" rel="[[rel]]" target="[[target]]" type="[[type]]">
+				<div class="d2l-card-header"><slot name="header"></slot></div>
+				<div class="d2l-card-badge"><slot name="badge"></slot></div>
+				<div class="d2l-card-content"><slot name="content"></slot></div>
+			</a>
+			<div class="d2l-card-actions">
+				<slot name="actions"></slot>
+			</div>
+			<div class="d2l-card-footer">
+				<div class="d2l-card-footer-content"><slot name="footer"></slot></div>
+			</div>
+		</div>
 	</template>
 
 	<script>
 		Polymer({
 			is: 'd2l-card',
+
+			behaviors: [
+				D2L.PolymerBehaviors.Link.Behavior,
+				D2L.PolymerBehaviors.FocusableBehavior
+			],
 
 			properties: {
 
@@ -51,6 +122,72 @@ Polymer-based web components for card
 					type: Boolean
 				}
 
+			},
+
+			ready: function() {
+				this._onBadgeChanges = this._onBadgeChanges.bind(this);
+				this._onFooterChanges = this._onFooterChanges.bind(this);
+				this._onLinkBlur = this._onLinkBlur.bind(this);
+				this._onLinkFocus = this._onLinkFocus.bind(this);
+			},
+
+			attached: function() {
+				var badge = Polymer.dom(this.root).querySelector('.d2l-card-badge');
+				var footer = Polymer.dom(this.root).querySelector('.d2l-card-footer');
+				this._badgeObserver = Polymer.dom(badge).observeNodes(this._onBadgeChanges);
+				this._footerObserver = Polymer.dom(footer).observeNodes(this._onFooterChanges);
+				Polymer.RenderStatus.afterNextRender(this, function() {
+					var link = Polymer.dom(this.root).querySelector('a');
+					link.addEventListener('blur', this._onLinkBlur);
+					link.addEventListener('focus', this._onLinkFocus);
+				}.bind(this));
+			},
+
+			detached: function() {
+				var badge = Polymer.dom(this.root).querySelector('.d2l-card-badge');
+				var footer = Polymer.dom(this.root).querySelector('.d2l-card-footer');
+				if (this._badgeObserver) Polymer.dom(badge).unobserveNodes(this._badgeObserver);
+				if (this._footerObserver) Polymer.dom(footer).unobserveNodes(this._footerObserver);
+				var link = Polymer.dom(this.root).querySelector('a');
+				link.removeEventListener('blur', this._onLinkBlur);
+				link.removeEventListener('focus', this._onLinkFocus);
+			},
+
+			_onBadgeChanges: function(data) {
+				var elems = this.getEffectiveChildren();
+				if (!elems || elems.length === 0) {
+					return;
+				}
+				fastdom.measure(function() {
+					var height = data.target.getBoundingClientRect().height;
+					fastdom.mutate(function() {
+						data.target.style.marginTop = (-0.5 * height) + 'px';
+					});
+				});
+			},
+
+			_onFooterChanges: function(data) {
+				var elems = D2L.Dom.getComposedChildren(data.target.querySelector('.d2l-card-footer-content'));
+				var hasFooter = false;
+				if (elems.length > 0) {
+					if (elems[0].tagName === 'SLOT') elems = elems[0].assignedNodes();
+					hasFooter = (elems.length > 0);
+				}
+				fastdom.mutate(function() {
+					if (hasFooter) {
+						data.target.setAttribute('shown', 'shown');
+					} else {
+						data.target.removeAttribute('shown');
+					}
+				});
+			},
+
+			_onLinkBlur: function() {
+				this.removeAttribute('active', 'active');
+			},
+
+			_onLinkFocus: function() {
+				this.setAttribute('active', 'active');
 			}
 
 		});

--- a/d2l-card.html
+++ b/d2l-card.html
@@ -2,6 +2,7 @@
 <link rel="import" href="../d2l-colors/d2l-colors.html">
 <link rel="import" href="../d2l-fastdom-import/fastdom.html">
 <link rel="import" href="../d2l-link/d2l-link-behavior.html">
+<link rel="import" href="../d2l-offscreen/d2l-offscreen-shared-styles.html">
 <link rel="import" href="../d2l-polymer-behaviors/d2l-dom.html">
 <link rel="import" href="../d2l-polymer-behaviors/d2l-focusable-behavior.html">
 
@@ -15,7 +16,7 @@ Polymer-based web components for card
 <dom-module id="d2l-card">
 
 	<template strip-whitespace>
-		<style>
+		<style include="d2l-offscreen-shared-styles">
 			:host {
 				background-color: #ffffff;
 				border: 1px solid var(--d2l-color-gypsum);
@@ -30,12 +31,19 @@ Polymer-based web components for card
 				position: relative;
 				height: 100%;
 			}
-			a {
-				color: var(--d2l-color-ferrite);
-				display: block;
+			.d2l-card-link-container {
 				flex: 1;
-				outline: none;
-				text-decoration: none;
+			}
+			.d2l-card-link-text {
+				display: inline-block;
+				@apply --d2l-offscreen;
+			}
+			a.d2l-focusable {
+				display: block;
+				position: absolute;
+				height: 100%;
+				width: 100%;
+				z-index: 1;
 			}
 			.d2l-card-content {
 				padding: 1.5rem 1.2rem;
@@ -44,6 +52,7 @@ Polymer-based web components for card
 				position: absolute;
 				right: 0.6rem;
 				top: 0.6rem;
+				z-index: 2;
 			}
 			/* P2-shadow */
 			:host-context([dir="rtl"]) .d2l-card-actions {
@@ -63,6 +72,7 @@ Polymer-based web components for card
 				display: none;
 				flex: none;
 				padding: 0 1.2rem;
+				z-index: 2;
 			}
 			.d2l-card-footer[shown] {
 				display: block;
@@ -98,11 +108,14 @@ Polymer-based web components for card
 
 		</style>
 		<div class="d2l-card-container">
-			<a class="d2l-focusable" aria-label="Jovian" download$="[[download]]" href$="[[href]]" hreflang="[[hreflang]]" rel="[[rel]]" target="[[target]]" type="[[type]]">
+			<div class="d2l-card-link-container">
+				<a class="d2l-focusable" aria-label="Jovian" download$="[[download]]" href$="[[href]]" hreflang="[[hreflang]]" rel="[[rel]]" target="[[target]]" type="[[type]]">
+					<span class="d2l-card-link-text">[[text]]</span>
+				</a>
 				<div class="d2l-card-header"><slot name="header"></slot></div>
 				<div class="d2l-card-badge"><slot name="badge"></slot></div>
 				<div class="d2l-card-content"><slot name="content"></slot></div>
-			</a>
+			</div>
 			<div class="d2l-card-actions">
 				<slot name="actions"></slot>
 			</div>
@@ -127,7 +140,16 @@ Polymer-based web components for card
 				 * Indicates whether subtle container style should be applied (for non-white backgrounds).
 				 */
 				subtle: {
-					type: Boolean
+					type: Boolean,
+					reflectToAttribute: true
+				},
+
+				/**
+				 * Accessible text for the link.
+				 */
+				text: {
+					type: String,
+					reflectToAttribute: true
 				}
 
 			},

--- a/d2l-card.html
+++ b/d2l-card.html
@@ -100,12 +100,11 @@ Polymer-based web components for card
 				box-shadow: 0 0 0 4px rgba(0, 111, 191, 0.3);
 				transform: translateY(-4px);
 			}
-
-			:host .d2l-card-actions ::slotted(d2l-button-icon) {
-				--d2l-button-icon-min-height: 1.8rem;
-				--d2l-button-icon-min-width: 1.8rem;
+			:host(:not([href])),
+			:host([subtle]:not([href])) {
+				box-shadow: none;
+				transform: none;
 			}
-
 		</style>
 		<div class="d2l-card-container">
 			<div class="d2l-card-link-container">

--- a/demo/d2l-card.html
+++ b/demo/d2l-card.html
@@ -37,7 +37,7 @@
 	<body unresolved class="d2l-typography">
 		<div class="vertical-section-container centered">
 
-			<h3>Card</h3>
+			<h3>Card (subtle)</h3>
 
 			<demo-snippet>
 				<template>
@@ -50,7 +50,42 @@
 							<div slot="content">
 								<d2l-card-content-title>Jupiter</d2l-card-content-title>
 								<d2l-card-content-meta>
-									Gas Giant
+									<div>Gas Giant</div>
+									<div>Orbital Period: 11.86yr</div>
+									<div>Orbital Speed: 13.07km/s</div>
+									<div>Known Satellites: 79</div>
+									<div>Volume: 1321 Earths</div>
+									<div>Mass: 317.8 Earths</div>
+									<div>Surface Temp: 165-112K</div>
+								</d2l-card-content-meta>
+							</div>
+							<img slot="badge" alt="" class="badge" src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cc/Galileo.arp.300pix.jpg/195px-Galileo.arp.300pix.jpg">
+							<div slot="footer">Secondary Actions</div>
+						</d2l-card>
+					</div>
+				</template>
+			</demo-snippet>
+
+			<h3>Card (subtle, no link)</h3>
+
+			<demo-snippet>
+				<template>
+					<div class="subtle-demo">
+						<d2l-card subtle text="Jovian"
+							style="width: 300px; height: 500px;">
+							<img slot="header" alt="" style="display: block; width: 100%; height: 150px;" src="https://www.nasa.gov/sites/default/files/thumbnails/image/pia21970-opt.jpg" />
+							<d2l-button-icon slot="actions" text="unpin" icon="d2l-tier1:pin-filled"></d2l-button-icon>
+							<d2l-button-icon slot="actions" text="more" icon="d2l-tier1:more"></d2l-button-icon>
+							<div slot="content">
+								<d2l-card-content-title>Jupiter</d2l-card-content-title>
+								<d2l-card-content-meta>
+									<div>Gas Giant</div>
+									<div>Orbital Period: 11.86yr</div>
+									<div>Orbital Speed: 13.07km/s</div>
+									<div>Known Satellites: 79</div>
+									<div>Volume: 1321 Earths</div>
+									<div>Mass: 317.8 Earths</div>
+									<div>Surface Temp: 165-112K</div>
 								</d2l-card-content-meta>
 							</div>
 							<img slot="badge" alt="" class="badge" src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cc/Galileo.arp.300pix.jpg/195px-Galileo.arp.300pix.jpg">
@@ -72,7 +107,40 @@
 						<div slot="content">
 							<d2l-card-content-title>Jupiter</d2l-card-content-title>
 							<d2l-card-content-meta>
-								Gas Giant
+								<div>Gas Giant</div>
+								<div>Orbital Period: 11.86yr</div>
+								<div>Orbital Speed: 13.07km/s</div>
+								<div>Known Satellites: 79</div>
+								<div>Volume: 1321 Earths</div>
+								<div>Mass: 317.8 Earths</div>
+								<div>Surface Temp: 165-112K</div>
+							</d2l-card-content-meta>
+						</div>
+						<img slot="badge" alt="" class="badge" src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cc/Galileo.arp.300pix.jpg/195px-Galileo.arp.300pix.jpg">
+						<div slot="footer">Secondary Actions</div>
+					</d2l-card>
+				</template>
+			</demo-snippet>
+
+			<h3>Card (no link)</h3>
+
+			<demo-snippet>
+				<template>
+					<d2l-card text="Jovian"
+						style="width: 300px; height: 500px;">
+						<img slot="header" alt="" style="display: block; width: 100%; height: 150px;" src="https://www.nasa.gov/sites/default/files/thumbnails/image/pia21970-opt.jpg" />
+						<d2l-button-icon slot="actions" text="unpin" icon="d2l-tier1:pin-filled"></d2l-button-icon>
+						<d2l-button-icon slot="actions" text="more" icon="d2l-tier1:more"></d2l-button-icon>
+						<div slot="content">
+							<d2l-card-content-title>Jupiter</d2l-card-content-title>
+							<d2l-card-content-meta>
+								<div>Gas Giant</div>
+								<div>Orbital Period: 11.86yr</div>
+								<div>Orbital Speed: 13.07km/s</div>
+								<div>Known Satellites: 79</div>
+								<div>Volume: 1321 Earths</div>
+								<div>Mass: 317.8 Earths</div>
+								<div>Surface Temp: 165-112K</div>
 							</d2l-card-content-meta>
 						</div>
 						<img slot="badge" alt="" class="badge" src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cc/Galileo.arp.300pix.jpg/195px-Galileo.arp.300pix.jpg">

--- a/demo/d2l-card.html
+++ b/demo/d2l-card.html
@@ -42,8 +42,7 @@
 			<demo-snippet>
 				<template>
 					<div class="subtle-demo">
-						<d2l-card subtle
-							href="https://en.wikipedia.org/wiki/Jupiter"
+						<d2l-card subtle text="Jovian" href="https://en.wikipedia.org/wiki/Jupiter"
 							style="width: 300px; height: 500px;">
 							<img slot="header" alt="" style="display: block; width: 100%; height: 150px;" src="https://www.nasa.gov/sites/default/files/thumbnails/image/pia21970-opt.jpg" />
 							<d2l-button-icon slot="actions" text="unpin" icon="d2l-tier1:pin-filled"></d2l-button-icon>
@@ -65,7 +64,7 @@
 
 			<demo-snippet>
 				<template>
-					<d2l-card href="https://en.wikipedia.org/wiki/Jupiter"
+					<d2l-card text="Jovian" href="https://en.wikipedia.org/wiki/Jupiter"
 						style="width: 300px; height: 500px;">
 						<img slot="header" alt="" style="display: block; width: 100%; height: 150px;" src="https://www.nasa.gov/sites/default/files/thumbnails/image/pia21970-opt.jpg" />
 						<d2l-button-icon slot="actions" text="unpin" icon="d2l-tier1:pin-filled"></d2l-button-icon>

--- a/demo/d2l-card.html
+++ b/demo/d2l-card.html
@@ -12,6 +12,8 @@
 		<link rel="import" href="../../d2l-button/d2l-button-icon.html">
 		<link rel="import" href="../../d2l-icons/tier1-icons.html">
 		<link rel="import" href="../d2l-card.html">
+		<link rel="import" href="../d2l-card-content-title.html">
+		<link rel="import" href="../d2l-card-content-meta.html">
 		<custom-style>
 			<style is="custom-style" include="demo-pages-shared-styles"></style>
 		</custom-style>
@@ -26,6 +28,9 @@
 				background-color: #f6f7f8;
 				margin: -20px;
 				padding: 20px;
+			}
+			.badge {
+				object-fit: cover; height: 100px; border-radius: 6px; border: 1px solid white;
 			}
 		</style>
 	</head>
@@ -43,8 +48,13 @@
 							<img slot="header" alt="" style="display: block; width: 100%; height: 150px;" src="https://www.nasa.gov/sites/default/files/thumbnails/image/pia21970-opt.jpg" />
 							<d2l-button-icon slot="actions" text="unpin" icon="d2l-tier1:pin-filled"></d2l-button-icon>
 							<d2l-button-icon slot="actions" text="more" icon="d2l-tier1:more"></d2l-button-icon>
-							<div slot="content">Jupiter</div>
-							<img slot="badge" alt="" style="object-fit: cover; height: 100px;" src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cc/Galileo.arp.300pix.jpg/195px-Galileo.arp.300pix.jpg">
+							<div slot="content">
+								<d2l-card-content-title>Jupiter</d2l-card-content-title>
+								<d2l-card-content-meta>
+									Gas Giant
+								</d2l-card-content-meta>
+							</div>
+							<img slot="badge" alt="" class="badge" src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cc/Galileo.arp.300pix.jpg/195px-Galileo.arp.300pix.jpg">
 							<div slot="footer">Secondary Actions</div>
 						</d2l-card>
 					</div>
@@ -60,8 +70,13 @@
 						<img slot="header" alt="" style="display: block; width: 100%; height: 150px;" src="https://www.nasa.gov/sites/default/files/thumbnails/image/pia21970-opt.jpg" />
 						<d2l-button-icon slot="actions" text="unpin" icon="d2l-tier1:pin-filled"></d2l-button-icon>
 						<d2l-button-icon slot="actions" text="more" icon="d2l-tier1:more"></d2l-button-icon>
-						<div slot="content">Jupiter</div>
-						<img slot="badge" alt="" style="object-fit: cover; height: 100px;" src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cc/Galileo.arp.300pix.jpg/195px-Galileo.arp.300pix.jpg">
+						<div slot="content">
+							<d2l-card-content-title>Jupiter</d2l-card-content-title>
+							<d2l-card-content-meta>
+								Gas Giant
+							</d2l-card-content-meta>
+						</div>
+						<img slot="badge" alt="" class="badge" src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cc/Galileo.arp.300pix.jpg/195px-Galileo.arp.300pix.jpg">
 						<div slot="footer">Secondary Actions</div>
 					</d2l-card>
 				</template>

--- a/demo/d2l-card.html
+++ b/demo/d2l-card.html
@@ -9,6 +9,8 @@
 		<link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
 		<link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
 		<link rel="import" href="../../d2l-typography/d2l-typography.html">
+		<link rel="import" href="../../d2l-button/d2l-button-icon.html">
+		<link rel="import" href="../../d2l-icons/tier1-icons.html">
 		<link rel="import" href="../d2l-card.html">
 		<custom-style>
 			<style is="custom-style" include="demo-pages-shared-styles"></style>
@@ -35,13 +37,31 @@
 			<demo-snippet>
 				<template>
 					<div class="subtle-demo">
-					<d2l-card subtle>
-						<div slot="header">
-							<img style="width: 300px; height: 150px;" src="https://www.nasa.gov/sites/default/files/thumbnails/image/pia21970-opt.jpg" />
-						</div>
-						<div slot="content">
-							Jupiter
-						</div>
+						<d2l-card subtle
+							href="https://en.wikipedia.org/wiki/Jupiter"
+							style="width: 300px; height: 500px;">
+							<img slot="header" alt="" style="display: block; width: 100%; height: 150px;" src="https://www.nasa.gov/sites/default/files/thumbnails/image/pia21970-opt.jpg" />
+							<d2l-button-icon slot="actions" text="unpin" icon="d2l-tier1:pin-filled"></d2l-button-icon>
+							<d2l-button-icon slot="actions" text="more" icon="d2l-tier1:more"></d2l-button-icon>
+							<div slot="content">Jupiter</div>
+							<img slot="badge" alt="" style="object-fit: cover; height: 100px;" src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cc/Galileo.arp.300pix.jpg/195px-Galileo.arp.300pix.jpg">
+							<div slot="footer">Secondary Actions</div>
+						</d2l-card>
+					</div>
+				</template>
+			</demo-snippet>
+
+			<h3>Card</h3>
+
+			<demo-snippet>
+				<template>
+					<d2l-card href="https://en.wikipedia.org/wiki/Jupiter"
+						style="width: 300px; height: 500px;">
+						<img slot="header" alt="" style="display: block; width: 100%; height: 150px;" src="https://www.nasa.gov/sites/default/files/thumbnails/image/pia21970-opt.jpg" />
+						<d2l-button-icon slot="actions" text="unpin" icon="d2l-tier1:pin-filled"></d2l-button-icon>
+						<d2l-button-icon slot="actions" text="more" icon="d2l-tier1:more"></d2l-button-icon>
+						<div slot="content">Jupiter</div>
+						<img slot="badge" alt="" style="object-fit: cover; height: 100px;" src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cc/Galileo.arp.300pix.jpg/195px-Galileo.arp.300pix.jpg">
 						<div slot="footer">Secondary Actions</div>
 					</d2l-card>
 				</template>

--- a/demo/d2l-card.html
+++ b/demo/d2l-card.html
@@ -10,6 +10,7 @@
 		<link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
 		<link rel="import" href="../../d2l-typography/d2l-typography.html">
 		<link rel="import" href="../../d2l-button/d2l-button-icon.html">
+		<link rel="import" href="../../d2l-status-indicator/d2l-status-indicator.html">
 		<link rel="import" href="../../d2l-icons/tier1-icons.html">
 		<link rel="import" href="../d2l-card.html">
 		<link rel="import" href="../d2l-card-content-title.html">
@@ -30,7 +31,16 @@
 				padding: 20px;
 			}
 			.badge {
-				object-fit: cover; height: 100px; border-radius: 6px; border: 1px solid white;
+				object-fit: cover;
+				height: 100px;
+				border-radius: 6px;
+				border: 1px solid white;
+			}
+			.badge-status {
+				background-color: white;
+				border: 1px solid white;
+				border-radius: 0.6rem;
+				display: inline-block;
 			}
 		</style>
 	</head>
@@ -60,6 +70,37 @@
 								</d2l-card-content-meta>
 							</div>
 							<img slot="badge" alt="" class="badge" src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cc/Galileo.arp.300pix.jpg/195px-Galileo.arp.300pix.jpg">
+							<div slot="footer">Secondary Actions</div>
+						</d2l-card>
+					</div>
+				</template>
+			</demo-snippet>
+
+			<h3>Card (status indicator badge)</h3>
+
+			<demo-snippet>
+				<template>
+					<div class="subtle-demo">
+						<d2l-card subtle text="Jovian" href="https://en.wikipedia.org/wiki/Jupiter"
+							style="width: 300px; height: 500px;">
+							<img slot="header" alt="" style="display: block; width: 100%; height: 150px;" src="https://www.nasa.gov/sites/default/files/thumbnails/image/pia21970-opt.jpg" />
+							<d2l-button-icon slot="actions" text="unpin" icon="d2l-tier1:pin-filled"></d2l-button-icon>
+							<d2l-button-icon slot="actions" text="more" icon="d2l-tier1:more"></d2l-button-icon>
+							<div slot="content">
+								<d2l-card-content-title>Jupiter</d2l-card-content-title>
+								<d2l-card-content-meta>
+									<div>Gas Giant</div>
+									<div>Orbital Period: 11.86yr</div>
+									<div>Orbital Speed: 13.07km/s</div>
+									<div>Known Satellites: 79</div>
+									<div>Volume: 1321 Earths</div>
+									<div>Mass: 317.8 Earths</div>
+									<div>Surface Temp: 165-112K</div>
+								</d2l-card-content-meta>
+							</div>
+							<div class="badge-status" slot="badge">
+								<d2l-status-indicator text="Success" state="success"></d2l-status-indicator>
+							</div>
 							<div slot="footer">Secondary Actions</div>
 						</d2l-card>
 					</div>


### PR DESCRIPTION
Some key changes in this PR:

* addition of badge slot
* addition of actions slot (top right corner of card)
* addition of text attribute for accessible text (this is what is announced)
* addition of title and meta components for use inside the content area
* layout change to make header + content the link click target.  assumes no clickable items inside content slot
* box-shadow and "lift" transition is dropped when no href is specified

My original approach used the `a` to wrap the header and content, however this presented an a11y issue because a) it makes contents of the card a pain to navigate with virtual cursor, or impossible if aria-label is used; b) it makes it difficult for users of speech-to-text AT to activate the link.  So, the anchor is not a container for all the content, but is given a higher stacking context and full height/width so that right-clicking still provides the user with the expected link options clicking anywhere in the header or content.